### PR TITLE
Added code to allow support for 'aurora-postgresql' and RDSInstances default to graviton processors

### DIFF
--- a/cmd/config/config.yaml
+++ b/cmd/config/config.yaml
@@ -7,8 +7,9 @@ region: us-west-1
 vpcSecurityGroupIDRefs: seizadi-bloxinabox-rds-sg
 dbSubnetGroupNameRef: seizadi-bloxinabox-rds-subnetgroup
 dynamicHostWaitTimeMin: 1
-defaultShape: db.t2.small
+defaultShape: db.t4g.medium
 defaultMinStorageGB: 20
+defaultEngine: postgres
 defaultEngineVersion: 12.8
 defaultMasterPort: 5432
 defaultSslMode: require
@@ -36,8 +37,9 @@ dynamic-connection:
   port: 5432
   sslMode: require
   passwordSecretRef: dynamic-connection-secret
-  shape: db.t2.small
+  shape: db.t4g.medium
   minStorageGB: 20
+  engine: postgres
   engineVersion: 12.8
   reclaimPolicy: delete
 another.connection:

--- a/controllers/databaseclaim_controller.go
+++ b/controllers/databaseclaim_controller.go
@@ -571,15 +571,12 @@ type DynamicHostParms struct {
 func (r *DatabaseClaimReconciler) getDynamicHostParams(ctx context.Context, fragmentKey string, dbClaim *persistancev1.DatabaseClaim) DynamicHostParms {
 	params := DynamicHostParms{}
 
-	// Only Support Postgres right now ignore Claim Type value
-	// Engine: dbClaim.Spec.Type,
-	params.Engine = "postgres"
-
 	// Database Config
 	if fragmentKey == "" {
 		params.MasterUsername = r.Config.GetString("defaultMasterUsername")
 		params.EngineVersion = r.Config.GetString("defaultEngineVersion")
 		params.Shape = dbClaim.Spec.Shape
+		params.Engine = dbClaim.Spec.Type
 		params.MinStorageGB = dbClaim.Spec.MinStorageGB
 	} else {
 		params.MasterUsername = r.getMasterUser(fragmentKey, dbClaim)
@@ -600,6 +597,10 @@ func (r *DatabaseClaimReconciler) getDynamicHostParams(ctx context.Context, frag
 
 	if params.Shape == "" {
 		params.Shape = r.Config.GetString("defaultShape")
+	}
+
+	if params.Engine == "" {
+		params.Engine = r.Config.GetString("defaultEngine")
 	}
 
 	if params.MinStorageGB == 0 {
@@ -656,8 +657,6 @@ func (r *DatabaseClaimReconciler) createCloudDatabase(dbHostName string, ctx con
 					Name: r.getDbSubnetGroupNameRef(),
 				},
 				// Items from Claim and fragmentKey
-				// Only Support Postgres right now ignore Claim Type value
-				// Engine: dbClaim.Spec.Type,
 				Engine:           params.Engine,
 				DBInstanceClass:  params.Shape,
 				AllocatedStorage: &params.MinStorageGB,

--- a/controllers/databaseclaim_controller.go
+++ b/controllers/databaseclaim_controller.go
@@ -710,24 +710,28 @@ func (r *DatabaseClaimReconciler) deleteCloudDatabase(dbHostName string, ctx con
 func (r *DatabaseClaimReconciler) updateCloudDatabase(ctx context.Context, fragmentKey string, dbClaim *persistancev1.DatabaseClaim, rdsInstance *crossplanedb.RDSInstance) (bool, error) {
 
 	update := false
-	params := r.getDynamicHostParams(ctx, fragmentKey, dbClaim)
 
-	// Update RDSInstance
-	// Update Shape and MinGibStorage for now
-	if rdsInstance.Spec.ForProvider.DBInstanceClass != params.Shape {
-		rdsInstance.Spec.ForProvider.DBInstanceClass = params.Shape
-		update = true
-	}
+	// TODO:currently ignoring changes to shape and minStorage if an RDSInstance CR already exists.
+	/*
+		params := r.getDynamicHostParams(ctx, fragmentKey, dbClaim)
 
-	if *rdsInstance.Spec.ForProvider.AllocatedStorage != params.MinStorageGB {
-		rdsInstance.Spec.ForProvider.AllocatedStorage = &params.MinStorageGB
-		update = true
-	}
+		// Update RDSInstance
+		// Update Shape and MinGibStorage for now
+		if rdsInstance.Spec.ForProvider.DBInstanceClass != params.Shape {
+			rdsInstance.Spec.ForProvider.DBInstanceClass = params.Shape
+			update = true
+		}
 
-	if update {
-		r.Log.Info("updating crossplane RDSInstance resource", "RDSInstance", rdsInstance.Name)
-		return update, r.Client.Update(ctx, rdsInstance)
-	}
+		if *rdsInstance.Spec.ForProvider.AllocatedStorage != params.MinStorageGB {
+			rdsInstance.Spec.ForProvider.AllocatedStorage = &params.MinStorageGB
+			update = true
+		}
+
+		if update {
+			r.Log.Info("updating crossplane RDSInstance resource", "RDSInstance", rdsInstance.Name)
+			return update, r.Client.Update(ctx, rdsInstance)
+		}
+	*/
 
 	return update, nil
 }

--- a/helm/db-controller/values.yaml
+++ b/helm/db-controller/values.yaml
@@ -107,8 +107,9 @@ controllerConfig:
   vpcSecurityGroupIDRefs: seizadi-bloxinabox-rds-sg
   dbSubnetGroupNameRef: seizadi-bloxinabox-rds-subnetgroup
   dynamicHostWaitTimeMin: 1
-  defaultShape: db.t2.small
+  defaultShape: db.t4g.medium
   defaultMinStorageGB: 20
+  defaultEngine: postgres
   defaultEngineVersion: 12.8
   defaultMasterPort: 5432
   defaultSslMode: require
@@ -135,8 +136,9 @@ controllerConfig:
     port: 5432
     sslMode: require
     passwordSecretRef: dynamic-connection-secret
-    shape: db.t2.small
+    shape: db.t4g.medium
     minStorageGB: 20
+    engine: postgres
     engineVersion: 12.8
     reclaimPolicy: delete
   another.connection:


### PR DESCRIPTION
Specified the `defaultShape` as `db.t4g.medium`, which is the smallest size supported by aurora-postgresql.
Specified the `defaultEngine` as `postgres`.

RDSInstance CR is created with `Engine` based on the value provided in the DatabaseClaim CR.
