### PR TITLE
fix special characters in password for key/value connection string

### DIFF
--- a/pkg/dbclient/client.go
+++ b/pkg/dbclient/client.go
@@ -96,8 +96,8 @@ func newPostgresClient(ctx context.Context, cfg Config) (*client, error) {
 }
 
 func PostgresConnectionString(host, port, user, password, dbname, sslmode string) string {
-	return fmt.Sprintf("host='%s' port='%s' user='%s' password='%s' dbname='%s' sslmode='%s'", host,
-		port, url.QueryEscape(user), url.QueryEscape(password), url.QueryEscape(dbname), sslmode)
+	return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s", host,
+		port, escapeValue(user), escapeValue(password), escapeValue(dbname), sslmode)
 }
 
 func PostgresURI(host, port, user, password, dbname, sslmode string) string {
@@ -364,6 +364,15 @@ func escapeValue(in string) string {
 		case '\'':
 			encoded = append(encoded, '\\')
 			encoded = append(encoded, '\'')
+		case '`':
+			encoded = append(encoded, '\\')
+			encoded = append(encoded, '`')
+		case '$':
+			encoded = append(encoded, '\\')
+			encoded = append(encoded, '$')
+		case '!':
+			encoded = append(encoded, '\\')
+			encoded = append(encoded, '!')
 		default:
 			encoded = append(encoded, c)
 		}


### PR DESCRIPTION
key/value connection string did not require url.escape.
But did ended up reverting my prev changes and adding to the  previous escape some of the special characters with "\\". 
did add a couple of unit test to validate the changes.