### PR TITLE
fix source admin dsn being lost during migration

### DIFF
--- a/pkg/pgctl/pgctl.go
+++ b/pkg/pgctl/pgctl.go
@@ -70,19 +70,10 @@ var _ State = &delete_publication_state{}
 var _ State = &completed_state{}
 var _ State = &retry_state{}
 
-// func GetReplicatorState(log logr.Logger, sourceDBAdminDsn string, sourceDBUserDsn string, targetDBAdminDsn string, targetDBUserDsn string, stateName string) (State, error) {
-
-// 	return getCurrentState(stateName, Config{Log: log,
-// 		SourceDBAdminDsn: sourceDBAdminDsn,
-// 		SourceDBUserDsn:  sourceDBUserDsn,
-// 		TargetDBAdminDsn: targetDBAdminDsn,
-// 		TargetDBUserDsn:  targetDBUserDsn})
-// }
-
 func GetReplicatorState(name string, c Config) (State, error) {
 	log := c.Log.WithValues("state", name)
 
-	stateEnum, err := getStateEnum(name)
+	stateEnum, err := GetStateEnum(name)
 	if err != nil {
 		log.Error(err, "error while getting current state")
 		return nil, err

--- a/pkg/pgctl/stateEnum.go
+++ b/pkg/pgctl/stateEnum.go
@@ -89,7 +89,7 @@ func init() {
 	stateMap[S_Retry.String()] = S_Retry
 }
 
-func getStateEnum(name string) (StateEnum, error) {
+func GetStateEnum(name string) (StateEnum, error) {
 	if s, present := stateMap[name]; present {
 		return s, nil
 	} else {


### PR DESCRIPTION
source dsn which was pulled from the secret used by the app was lost during migration process when the app secret was updated to point to new db.

stored the dsn in a temp secret before updating the app secret (to be used for later steps by dbc)

temp secret is cleaned up at the end of the migration process