### PR TITLE
Add dsn filename as specified in the dbclaim

### DIFF
--- a/config/postgres-exporter/deployment.yaml
+++ b/config/postgres-exporter/deployment.yaml
@@ -76,7 +76,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: "{{ .DatasourceSecretName }}"
-                key: dsn.txt
+                key: {{ .DatasourceFileName }}
           - name: DATA_SOURCE_USER
             value: {{ .DatasourceUser }}
           image: "{{ .ImageRepo }}:{{ .ImageTag }}"

--- a/controllers/databaseclaim_controller.go
+++ b/controllers/databaseclaim_controller.go
@@ -308,6 +308,7 @@ func (r *DatabaseClaimReconciler) createMetricsDeployment(ctx context.Context, d
 	cfg.DepYamlPath = r.MetricsDepYamlPath
 	cfg.ConfigYamlPath = r.MetricsConfigYamlPath
 	cfg.DatasourceSecretName = dbClaim.Spec.SecretName
+	cfg.DatasourceFileName = dbClaim.Spec.DSNName
 	return exporter.Apply(ctx, r.Client, cfg)
 }
 

--- a/pkg/postgres-exporter/render.go
+++ b/pkg/postgres-exporter/render.go
@@ -38,6 +38,7 @@ type Config struct {
 
 	DatasourceUser       string
 	DatasourceSecretName string
+	DatasourceFileName   string
 
 	Resources map[string]map[string]string
 
@@ -82,9 +83,11 @@ func MustReadValues(data []byte) Values {
 }
 
 var DefaultConfig = Config{
-	Release:   "dbclaim-exporter",
-	ImageRepo: "quay.io/prometheuscommunity/postgres-exporter",
-	ImageTag:  "v0.10.1",
+
+	Release:            "dbclaim-exporter",
+	ImageRepo:          "quay.io/prometheuscommunity/postgres-exporter",
+	ImageTag:           "v0.10.1",
+	DatasourceFileName: "dsn.txt",
 
 	Resources: map[string]map[string]string{
 		"requests": {

--- a/pkg/postgres-exporter/render_test.go
+++ b/pkg/postgres-exporter/render_test.go
@@ -96,6 +96,7 @@ func Test_render(t *testing.T) {
 				ServiceAccountName:   "robot",
 				DatasourceUser:       "data",
 				DatasourceSecretName: "secret/data",
+				DatasourceFileName:   "dsn.txt",
 				Resources: map[string]map[string]string{
 					"requests": {
 						"cpu":    "100m",
@@ -128,6 +129,7 @@ annotations:
 				ServiceAccountName:   "robot",
 				DatasourceUser:       "data",
 				DatasourceSecretName: "secret/data",
+				DatasourceFileName:   "dsn.txt",
 				Values: testReadValues(t, []byte(`
 podLabels:
   keyA: valueA
@@ -179,6 +181,7 @@ func TestRender(t *testing.T) {
 				ServiceAccountName:   "robot",
 				DatasourceUser:       "data",
 				DatasourceSecretName: "secret/data",
+				DatasourceFileName:   "dsn.txt",
 				Resources: map[string]map[string]string{
 					"requests": {
 						"cpu":    "100m",


### PR DESCRIPTION
Some apps don't have the dsn filename specified as `dsn.txt`. To support creating an exporter for these apps, this PR removes the hardcoded `dsn.txt` and supplies the dsn filename from the dbclaim.