### PR TITLE
Enable db proxy

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -179,7 +179,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		setupLog.Info("Parsed db proxy config:", cfg)
+		setupLog.Info("Parsed db proxy config:", "dbproxysidecarconfig", cfg)
 
 		setupLog.Info("registering with webhook server")
 		webHookServer.Register("/mutate", &webhook.Admission{

--- a/helm/db-controller/templates/deployment.yaml
+++ b/helm/db-controller/templates/deployment.yaml
@@ -56,7 +56,9 @@ spec:
             - --health-probe-address={{ .Values.healthProbe.address }}
             - --health-probe-port={{ .Values.healthProbe.port }}
             - --enable-leader-election
+            - --enable-db-proxy={{ .Values.dbproxy.enabled }}
             - --config-file=/etc/config/config.yaml
+            - --sidecar-config-path=config/dbproxy/dbproxysidecar.json
             - --db-identifier-prefix={{ .Values.db.identifier.prefix }}
             - --class={{ .Values.dbController.class }}
             {{ if .Values.zapLogger.develMode }}

--- a/helm/db-controller/templates/deployment.yaml
+++ b/helm/db-controller/templates/deployment.yaml
@@ -45,6 +45,8 @@ spec:
           ports:
           - containerPort: 8443
             name: https
+          - containerPort: 7443
+            name: webhook
           env:
             - name: SERVICE_NAMESPACE
               valueFrom:


### PR DESCRIPTION
`setupLog.Info` needs an even number of arguments after the initial string, which function as key-value pairs. Adding `"dbproxysidecarconfig"` back as the key, which was previously configured before it was removed.

The helm chart changes are to enable dbproxy in the controller as well as adding the webhook service port to the deployment.