### PR TITLE
Fix problem characters in password and force host change refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ The target code should create:
 * at least two logins that the controller and jump between
 
 Other strategies are possible and may be appropriate to implement.
+
+## Branch: `dbc-v1`
+This branch is used for maintaining the original db-controller code base, that is still used by some projects.
+
+**DO NOT MERGE WITH MASTER**

--- a/controllers/databaseclaim_controller.go
+++ b/controllers/databaseclaim_controller.go
@@ -194,8 +194,11 @@ func (r *DatabaseClaimReconciler) generatePassword() (string, error) {
 	complEnabled := r.isPasswordComplexity()
 
 	// Customize the list of symbols so we don't have characters that cause encoding issues
+	// To be overly cautious, these are characters that may cause issues when used in the password:
+	// issues with encoding: "`<>
+	// problems when used with connection strings: ;
 	gen, err := gopassword.NewGenerator(&gopassword.GeneratorInput{
-		Symbols: "~!$^*()_+-{}|[]:,.",
+		Symbols: "~!@#$%^&*()_+-={}|[]:<>?,./",
 	})
 	if err != nil {
 		return "", err

--- a/controllers/databaseclaim_controller.go
+++ b/controllers/databaseclaim_controller.go
@@ -82,6 +82,9 @@ func (r *DatabaseClaimReconciler) updateStatus(ctx context.Context, dbClaim *per
 		dbClaim.Status.ConnectionInfo = &persistancev1.DatabaseClaimConnectionInfo{}
 	}
 
+	// Grab opriginal host before it changes
+	originalHost := dbClaim.Status.ConnectionInfo.Host
+
 	fragmentKey, err := r.matchInstanceLabel(dbClaim)
 	if err != nil {
 		return r.manageError(ctx, dbClaim, err)
@@ -146,7 +149,8 @@ func (r *DatabaseClaimReconciler) updateStatus(ctx context.Context, dbClaim *per
 		}
 	}
 
-	if dbClaim.Status.UserUpdatedAt == nil || time.Since(dbClaim.Status.UserUpdatedAt.Time) > rotationTime {
+	// Force a user/password refresh if we do not have a user OR the rotation period has expired OR the host has changed
+	if dbClaim.Status.UserUpdatedAt == nil || time.Since(dbClaim.Status.UserUpdatedAt.Time) > rotationTime || originalHost != dbClaim.Status.ConnectionInfo.Host {
 		log.Info("rotating users")
 
 		userPassword, err := r.generatePassword()
@@ -189,14 +193,22 @@ func (r *DatabaseClaimReconciler) generatePassword() (string, error) {
 	minPasswordLength := r.getMinPasswordLength()
 	complEnabled := r.isPasswordComplexity()
 
+	// Customize the list of symbols so we don't have characters that cause encoding issues
+	gen, err := gopassword.NewGenerator(&gopassword.GeneratorInput{
+		Symbols: "~!$^*()_+-{}|[]:,.",
+	})
+	if err != nil {
+		return "", err
+	}
+
 	if complEnabled {
 		count := minPasswordLength / 4
-		pass, err = gopassword.Generate(minPasswordLength, count, count, false, false)
+		pass, err = gen.Generate(minPasswordLength, count, count, false, false)
 		if err != nil {
 			return "", err
 		}
 	} else {
-		pass, err = gopassword.Generate(defaultPassLen, defaultNumDig, defaultNumSimb, false, false)
+		pass, err = gen.Generate(defaultPassLen, defaultNumDig, defaultNumSimb, false, false)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
This PR contains the following fixes:
* Exclude symbol characters from password that could cause encoding/usage issues
* Force a user/password refresh if the host changes in the DBClaim
