### PR TITLE
use unescaped password for dbproxy

### DIFF
--- a/config/dbproxy/dbproxysidecar.json
+++ b/config/dbproxy/dbproxysidecar.json
@@ -20,6 +20,10 @@
           {
             "key": "...",
             "path": "db-credential"
+          },
+          {
+            "key": "...",
+            "path": "db-password"
           }
         ],
         "optional": false,

--- a/dbproxy/dbproxy.go
+++ b/dbproxy/dbproxy.go
@@ -10,8 +10,8 @@ import (
 	"infoblox.com/dbproxy/pgbouncer" // go.mod has a replace directive to make this relative path work.
 )
 
-func generatePGBouncerConfiguration(dbCredentialPath, pbCredentialPath *string) {
-	dbc, err := pgbouncer.ParseDBCredentials(dbCredentialPath)
+func generatePGBouncerConfiguration(dbCredentialPath, dbPasswordPath, pbCredentialPath *string) {
+	dbc, err := pgbouncer.ParseDBCredentials(dbCredentialPath, dbPasswordPath)
 	if err != nil {
 		log.Println(err)
 		panic(err)
@@ -70,6 +70,7 @@ func waitForDbCredentialFile(path *string) {
 
 func main() {
 	dbCredentialPath := flag.String("dbc", "./db-credential", "Location of the DB Credentials")
+	dbPasswordPath := flag.String("dbp", "./db-password", "Location of the unescaped DB Password")
 	pbCredentialPath := flag.String("pbc", "./pgbouncer.ini", "Location of the PGBouncer config file")
 
 	flag.Parse()
@@ -77,7 +78,7 @@ func main() {
 	waitForDbCredentialFile(dbCredentialPath)
 
 	// First time pgbouncer config generation and start
-	generatePGBouncerConfiguration(dbCredentialPath, pbCredentialPath)
+	generatePGBouncerConfiguration(dbCredentialPath, dbPasswordPath, pbCredentialPath)
 	startPGBouncer()
 
 	// Watch for ongoing changes and regenerate pgbouncer config
@@ -106,8 +107,8 @@ func main() {
 				if err != nil {
 					log.Fatal("Add failed:", err)
 				}
-                                // Regenerate pgbouncer configuration and signal pgbouncer to reload cconfiguration
-				generatePGBouncerConfiguration(dbCredentialPath, pbCredentialPath)
+				// Regenerate pgbouncer configuration and signal pgbouncer to reload cconfiguration
+				generatePGBouncerConfiguration(dbCredentialPath, dbPasswordPath, pbCredentialPath)
 				reloadPGBouncerConfiguration()
 			case err, ok := <-watcher.Errors:
 				if !ok {

--- a/dbproxy/pgbouncer/pgbouncer.go
+++ b/dbproxy/pgbouncer/pgbouncer.go
@@ -31,7 +31,7 @@ type PGBouncerConfig struct {
 	Password    *string
 }
 
-func ParseDBCredentials(path *string) (*DBCredential, error) {
+func ParseDBCredentials(path *string, passwordPath *string) (*DBCredential, error) {
 	content, err := ioutil.ReadFile(*path)
 
 	if err != nil {
@@ -56,6 +56,15 @@ func ParseDBCredentials(path *string) (*DBCredential, error) {
 			m[fieldPair[0]] = nil
 		}
 	}
+
+	passwordContent, err := ioutil.ReadFile(*passwordPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// override password from db credential file with unescaped password
+	password := string(passwordContent)
+	m["password"] = &password
 
 	if m["host"] == nil {
 		return nil, errors.New("host value not found in db credential")

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -26,6 +26,7 @@ type DBProxyInjector struct {
 var (
 	dbProxyLog   = ctrl.Log.WithName("dbproxy-controller")
 	sidecarImage = os.Getenv("DBPROXY_IMAGE")
+	passwordKey  = "password"
 )
 
 type Config struct {
@@ -98,6 +99,7 @@ func (dbpi *DBProxyInjector) Handle(ctx context.Context, req admission.Request) 
 
 			dbpi.DBProxySidecarConfig.Volumes[0].Secret.SecretName = dbSecretRef
 			dbpi.DBProxySidecarConfig.Volumes[0].Secret.Items[0].Key = dbSecretItem
+			dbpi.DBProxySidecarConfig.Volumes[0].Secret.Items[1].Key = passwordKey
 			dbpi.DBProxySidecarConfig.Containers[0].Image = sidecarImage
 
 			pod.Spec.Volumes = append(pod.Spec.Volumes, dbpi.DBProxySidecarConfig.Volumes...)


### PR DESCRIPTION
pgbouncer seem to be escaping the password, so passing unescaped password to dbproxy to avoid double escaping.