### PR TITLE
by default disable dbproxy injection while using local/minikube testing

### DIFF
--- a/helm/db-controller/minikube.yaml
+++ b/helm/db-controller/minikube.yaml
@@ -6,3 +6,5 @@ controllerConfig:
 zapLogger:
   develMode: true
   level: debug
+dbproxy:
+  enabled: false


### PR DESCRIPTION
fix for https://infoblox.atlassian.net/browse/ATLAS-17514