### PR TITLE
update sources on change

### DIFF
--- a/dsnexec/pkg/dsnexec/dsnexec.go
+++ b/dsnexec/pkg/dsnexec/dsnexec.go
@@ -58,6 +58,12 @@ func (w *Handler) UpdateDSN(path, content string) error {
 	w.l.RLock()
 	defer w.l.RUnlock()
 
+	// update the local state
+	w.config.Sources[path] = DBConnInfo{
+		Driver: w.config.Sources[path].Driver,
+		DSN:    content,
+	}
+
 	if err := w.exec(); err != nil {
 		return fmt.Errorf("failed initial execute: %v", err)
 	}

--- a/dsnexec/pkg/dsnexec/dsnexec_test.go
+++ b/dsnexec/pkg/dsnexec/dsnexec_test.go
@@ -71,12 +71,16 @@ func TestHandler_UpdateDSN(t *testing.T) {
 					},
 				},
 			},
+			args: args{
+				path:    "test",
+				content: "postgres://user:pass@myhost:1234/dbname?sslmode=disable",
+			},
 			expectedExecCalls: []tdb.ExecArgs{
 				{
 					Query: "select 1",
 					Args: []driver.Value{
-						"localhost",
-						int64(5432),
+						"myhost",
+						int64(1234),
 					},
 				},
 			},


### PR DESCRIPTION
The existing test didn't ensure that the updated DSN was being updated. This change verifies that the UpdateDSN call updates the local state before executing the command.