### PR TITLE
DO NOT MERGE - adding watch on dir instead of file to better handle file renames

### DIFF
--- a/dbproxy/dbproxy.go
+++ b/dbproxy/dbproxy.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"log"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -115,12 +116,21 @@ func main() {
 				if !ok {
 					return
 				}
+
+				if !event.Op.Has(fsnotify.Create) {
+					continue
+				}
+
+				if event.Name != filepath.Base(dbCredentialPath) {
+					continue
+				}
+
 				log.Printf("%s %s\n", event.Name, event.Op)
-				err := watcher.Remove(dbCredentialPath)
+				err := watcher.Remove(filepath.Dir(dbCredentialPath))
 				if err != nil {
 					log.Fatal("Remove failed:", err)
 				}
-				err = watcher.Add(dbCredentialPath)
+				err = watcher.Add(filepath.Dir(dbCredentialPath))
 				if err != nil {
 					log.Fatal("Add failed:", err)
 				}
@@ -137,7 +147,7 @@ func main() {
 
 	}()
 
-	err = watcher.Add(dbCredentialPath)
+	err = watcher.Add(filepath.Dir(dbCredentialPath))
 	if err != nil {
 		log.Fatal("Add failed:", err)
 	}


### PR DESCRIPTION
This change is made to keep a watcher on the directory instead of the file. This is  due to the underlying implementation of fsnotify which does not allow to remove watch added on file-descriptors if it is deleted/renamed. 

Assumption - here it is assumed that the db-credentials file is updated periodically by --- creating a temp file first with new contents and then replacing the actual db-credential file which is mapped to volume with it. 
