### PR TITLE
adding dsnexec as a sidecar [new]

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -32,6 +32,7 @@ jobs:
         echo 'db-controller-namespace' > .id
         make docker-build
         make docker-build-dbproxy
+        make docker-build-dsnexec
 
     - name: Push to GHCR
       env:
@@ -39,6 +40,7 @@ jobs:
       run: |
         make docker-push
         make docker-push-dbproxy
+        make docker-push-dsnexec
     - uses: act10ns/slack@v1
       with:
         status: ${{ job.status }}

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ REGISTRY ?= ghcr.io/infobloxopen
 # image name
 IMAGE_NAME ?= db-controller
 DBPROXY_IMAGE_NAME ?= dbproxy
+DSNEXEC_IMAGE_NAME ?= dsnexec
 # commit tag info from git repo
 GIT_COMMIT	   := $(shell git describe --always || echo pre-commit)
 # image tag
@@ -10,6 +11,7 @@ TAG ?= ${GIT_COMMIT}
 # Image Path to use all building/pushing image targets
 IMG_PATH ?= ${REGISTRY}/${IMAGE_NAME}
 DBPROXY_IMG_PATH ?= ${REGISTRY}/${DBPROXY_IMAGE_NAME}
+DSNEXEC_IMG_PATH ?= ${REGISTRY}/${DSNEXEC_IMAGE_NAME}
 GOBIN := ~/go/bin
 K8S_VERSION := 1.24
 # ACK_GINKGO_DEPRECATIONS := 1.16.5
@@ -143,6 +145,8 @@ test: manifests generate fmt vet envtest ## Run tests.
 build: generate fmt vet ## Build manager binary.
 	cd cmd/manager && go build -o ../../bin/manager main.go
 	cd dbproxy && go build -o ../bin/dbproxy
+	cd dsnexec && go build -o ../bin/dsnexec
+
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
@@ -160,6 +164,10 @@ docker-buildx: generate fmt vet manifests ## Build and optionally push a multi-a
 docker-build-dbproxy:
 	cd dbproxy && docker build -t ${DBPROXY_IMG_PATH}:${TAG} .
 
+docker-build-dsnexec:
+	cd dsnexec && docker build -t ${DSNEXEC_IMG_PATH}:${TAG} .
+
+
 .PHONY: docker-build
 docker-build: .image-${TAG} #test ## Build docker image with the manager.
 
@@ -170,6 +178,9 @@ docker-build: .image-${TAG} #test ## Build docker image with the manager.
 
 docker-push-dbproxy: docker-build-dbproxy
 	docker push ${DBPROXY_IMG_PATH}:${TAG}
+
+docker-push-dsnexec: docker-build-dsnexec
+	docker push ${DSNEXEC_IMG_PATH}:${TAG}
 
 .push-${TAG}: docker-build
 	docker push ${IMG_PATH}:${TAG}

--- a/config/dsnexec/dsnexecsidecar.json
+++ b/config/dsnexec/dsnexecsidecar.json
@@ -1,0 +1,35 @@
+{
+  "containers": [
+    {
+      "imagePullPolicy": "IfNotPresent",
+      "args": ["run","-c","/var/run/dsn-exec/config.yaml"],
+      "name": "dsn-exec",
+      "volumeMounts": [
+        {
+          "mountPath": "/var/run/db-dsn",
+          "name": "remote-db-dsn-volume"
+        },
+        {
+          "mountPath": "/var/run/dsn-exec",
+          "name": "dsnexec-config-volume"
+        }
+      ]
+    }
+  ],
+  "volumes": [
+    {
+      "name": "remote-db-dsn-volume",
+      "secret": {
+        "optional": false,
+        "secretName": "..."
+      }
+    },
+    {
+      "name": "dsnexec-config-volume",
+      "secret": {
+        "optional": false,
+        "secretName": "..."
+      }
+    }
+  ]
+}

--- a/helm/db-controller/templates/certs.yaml
+++ b/helm/db-controller/templates/certs.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.dbproxy.enabled }}
+{{- if or ( .Values.dbproxy.enabled ) ( .Values.dsnexec.enabled ) }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/helm/db-controller/templates/deployment.yaml
+++ b/helm/db-controller/templates/deployment.yaml
@@ -54,6 +54,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: DBPROXY_IMAGE
               value: "{{ .Values.dbproxy.image.repository }}:{{ .Values.dbproxy.image.tag | default .Chart.AppVersion }}"
+            - name: DSNEXEC_IMAGE
+              value: "{{ .Values.dsnexec.image.repository }}:{{ .Values.dsnexec.image.tag | default .Chart.AppVersion }}"
           args:
             - --metrics-addr={{ .Values.metrics.address }}
             - --metrics-port={{ .Values.metrics.port }}
@@ -61,8 +63,10 @@ spec:
             - --health-probe-port={{ .Values.healthProbe.port }}
             - --enable-leader-election
             - --enable-db-proxy={{ .Values.dbproxy.enabled }}
+            - --enable-dsnexec={{ .Values.dsnexec.enabled }}
             - --config-file=/etc/config/config.yaml
-            - --sidecar-config-path=config/dbproxy/dbproxysidecar.json
+            - --db-proxy-sidecar-config-path=config/dbproxy/dbproxysidecar.json
+            - --dsnexec-sidecar-config-path=config/dsnexec/dsnexecsidecar.json
             - --db-identifier-prefix={{ tpl .Values.db.identifier.prefix . }}
             - --class={{ .Values.dbController.class }}
             {{ if .Values.zapLogger.develMode }}
@@ -96,7 +100,7 @@ spec:
               mountPath: /pg-temp
             - name: config-volume
               mountPath: /etc/config
-            {{- if .Values.dbproxy.enabled }}
+            {{- if or ( .Values.dbproxy.enabled ) ( .Values.dsnexec.enabled ) }}
             - name: dbproxycert
               mountPath: /certs
               readOnly: true
@@ -107,7 +111,7 @@ spec:
       - name: config-volume
         configMap:
           name: {{ include "db-controller.name" . }}-config
-      {{- if .Values.dbproxy.enabled }}
+      {{- if or ( .Values.dbproxy.enabled ) ( .Values.dsnexec.enabled ) }}
       - name: dbproxycert
         secret:
           secretName: {{ include "db-controller.fullname" . }}

--- a/helm/db-controller/templates/webhook.yaml
+++ b/helm/db-controller/templates/webhook.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.dbproxy.enabled }}
+{{- if or ( .Values.dbproxy.enabled ) ( .Values.dsnexec.enabled ) }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -6,6 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "db-controller.fullname" . }}
 webhooks:
+{{- if .Values.dbproxy.enabled }}
 - clientConfig:
     caBundle: Cg==
     service:
@@ -28,4 +29,29 @@ webhooks:
     resources:
     - pods
     scope: "Namespaced"
+{{- end }}
+{{- if .Values.dsnexec.enabled }}
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: {{ include "db-controller.fullname" . }}
+      path: /mutate-dsnexec
+      port: 7443
+      namespace: {{ .Release.Namespace }}
+  sideEffects: None
+  admissionReviewVersions: ["v1"]
+  failurePolicy: Ignore
+  name: dsnexec-injector.infoblox.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+    scope: "Namespaced"
+{{- end }}
 {{- end }}

--- a/helm/db-controller/templates/webhook.yaml
+++ b/helm/db-controller/templates/webhook.yaml
@@ -34,7 +34,7 @@ webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: {{ include "db-controller.fullname" . }}
+      name: {{ include "db-controller.fullname" . }}-dsnexec
       path: /mutate-dsnexec
       port: 7443
       namespace: {{ .Release.Namespace }}

--- a/helm/db-controller/values.yaml
+++ b/helm/db-controller/values.yaml
@@ -106,6 +106,12 @@ dbproxy:
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
+dsnexec:
+  enabled: true
+  image:
+    repository: ""
+    tag: ""
+
 zapLogger:
   develMode: false
   level: info

--- a/helm/db-controller/values.yaml
+++ b/helm/db-controller/values.yaml
@@ -109,7 +109,7 @@ dbproxy:
 dsnexec:
   enabled: true
   image:
-    repository: ""
+    repository: "ghcr.io/infobloxopen/dsnexec"
     tag: ""
 
 zapLogger:

--- a/webhook/webhook-dsnexec.go
+++ b/webhook/webhook-dsnexec.go
@@ -26,12 +26,16 @@ var (
 	sidecarImageForDsnExec = os.Getenv("DSNEXEC_IMAGE")
 )
 
-func dsnExecSideCardInjectionRequired(pod *corev1.Pod) (bool, string, string) {
+func dsnExecSideCarInjectionRequired(pod *corev1.Pod) (bool, string, string) {
 	remoteDbSecretName, ok := pod.Annotations["infoblox.com/remote-db-dsn-secret"]
-	dsnExecConfigSecret, ok2 := pod.Annotations["infoblox.com/dsnexec-config-secret"]
+	if !ok {
+		dsnexecLog.Info("remote-db-dsn-secret can not be seen in the annotations.", pod.Name)
+		return false, "", ""
+	}
 
-	if !ok || !ok2 {
-		dsnexecLog.Info("either or both remote-db-dsn-secret, dsnexec-config-secret can not be seen in the annotations.", pod.Name)
+	dsnExecConfigSecret, ok := pod.Annotations["infoblox.com/dsnexec-config-secret"]
+	if !ok {
+		dsnexecLog.Info("dsnexec-config-secret can not be seen in the annotations.", pod.Name)
 		return false, "", ""
 	}
 
@@ -61,7 +65,7 @@ func (dbpi *DsnExecInjector) Handle(ctx context.Context, req admission.Request) 
 		pod.Annotations = map[string]string{}
 	}
 
-	shoudInjectDsnExec, remoteDbSecretName, dsnExecConfigSecret := dsnExecSideCardInjectionRequired(pod)
+	shoudInjectDsnExec, remoteDbSecretName, dsnExecConfigSecret := dsnExecSideCarInjectionRequired(pod)
 
 	if shoudInjectDsnExec {
 		dsnexecLog.Info("Injecting sidecar...")

--- a/webhook/webhook-dsnexec.go
+++ b/webhook/webhook-dsnexec.go
@@ -1,0 +1,99 @@
+package hook
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// DsnExecInjector annotates Pods
+type DsnExecInjector struct {
+	Name                 string
+	Client               client.Client
+	decoder              *admission.Decoder
+	DsnExecSidecarConfig *Config
+}
+
+var (
+	dsnexecLog             = ctrl.Log.WithName("dsnexec-controller")
+	sidecarImageForDsnExec = os.Getenv("DSNEXEC_IMAGE")
+)
+
+func dsnExecSideCardInjectionRequired(pod *corev1.Pod) (bool, string, string) {
+	remoteDbSecretName, ok := pod.Annotations["infoblox.com/remote-db-dsn-secret"]
+	dsnExecConfigSecret, ok2 := pod.Annotations["infoblox.com/dsnexec-config-secret"]
+
+	if !ok || !ok2 {
+		dsnexecLog.Info("either or both remote-db-dsn-secret, dsnexec-config-secret can not be seen in the annotations.", pod.Name)
+		return false, "", ""
+	}
+
+	alreadyInjected, err := strconv.ParseBool(pod.Annotations["infoblox.com/dsnexec-injected"])
+
+	if err == nil && alreadyInjected {
+		dsnexecLog.Info("DsnExec sidecar already injected: ", pod.Name, remoteDbSecretName, dsnExecConfigSecret)
+		return false, remoteDbSecretName, dsnExecConfigSecret
+	}
+
+	dsnexecLog.Info("DsnExec sidecar Injection required: ", pod.Name, remoteDbSecretName, dsnExecConfigSecret)
+
+	return true, remoteDbSecretName, dsnExecConfigSecret
+}
+
+// DsnExecInjector adds an annotation to every incoming pods.
+func (dbpi *DsnExecInjector) Handle(ctx context.Context, req admission.Request) admission.Response {
+	pod := &corev1.Pod{}
+
+	err := dbpi.decoder.Decode(req, pod)
+	if err != nil {
+		dsnexecLog.Info("Sdecar-Injector: cannot decode")
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+
+	shoudInjectDsnExec, remoteDbSecretName, dsnExecConfigSecret := dsnExecSideCardInjectionRequired(pod)
+
+	if shoudInjectDsnExec {
+		dsnexecLog.Info("Injecting sidecar...")
+
+		dbpi.DsnExecSidecarConfig.Containers[0].Image = sidecarImageForDsnExec
+		dbpi.DsnExecSidecarConfig.Volumes[0].Secret.SecretName = remoteDbSecretName
+		dbpi.DsnExecSidecarConfig.Volumes[1].Secret.SecretName = dsnExecConfigSecret
+
+		pod.Spec.Volumes = append(pod.Spec.Volumes, dbpi.DsnExecSidecarConfig.Volumes...)
+		pod.Spec.Containers = append(pod.Spec.Containers, dbpi.DsnExecSidecarConfig.Containers...)
+
+		pod.Annotations["infoblox.com/dsnexec-injected"] = "true"
+
+		dsnexecLog.Info("sidecar ontainer for ", dbpi.Name, " injected.", pod.Name, pod.APIVersion)
+
+	} else {
+		dsnexecLog.Info("dsnexec sidecar not needed.", pod.Name, pod.APIVersion)
+	}
+
+	marshaledPod, err := json.Marshal(pod)
+
+	if err != nil {
+		dsnexecLog.Info("dsnexec sidecar injection: cannot marshal")
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
+}
+
+// DsnExecInjector implements admission.DecoderInjector.
+// InjectDecoder injects the decoder.
+func (dbpi *DsnExecInjector) InjectDecoder(d *admission.Decoder) error {
+	dbpi.decoder = d
+	return nil
+}


### PR DESCRIPTION
This is to add dsnexec as a side-car container. 
Whenever db-controller would see following two annotations, it would add the sidecar.

        1. infoblox.com/remote-db-dsn-secret: < some-secret-name >
        2. infoblox.com/dsnexec-config-secret: < some-secret-name >
       
**_remote-db-dsn-secret_** - In case of RDS, it would be the secret created by DBClaim. This would be mounted as a volume inside the sidecar. the dsn.txt file can be watched for changes (by configuring such through dsnexec config.yaml).

**_dsnexec-config-secret_** - This would be a secret which needs to be created by the apps. This should contain data as

> key: config.yaml
> value:  < config needed for dsnexec >

This would be mounted as a volume inside the sidecar. The path to config.yaml file is given to the dsnexec entrypoint. 
  