### PR TITLE
mandate dbVersion

### DIFF
--- a/helm/db-controller/values.yaml
+++ b/helm/db-controller/values.yaml
@@ -132,10 +132,7 @@ controllerConfig:
   dbMultiAZEnabled: false
   dbSubnetGroupNameRef:
   defaultBackupPolicyValue: Bronze
-  defaultShape: db.t4g.medium
   defaultMinStorageGB: 50
-  defaultEngine: postgres
-  defaultEngineVersion: 15.3
   defaultMasterPort: 5432
   defaultSslMode: require
   defaultMasterUsername: root

--- a/pkg/pgctl/pgctl.go
+++ b/pkg/pgctl/pgctl.go
@@ -232,7 +232,7 @@ func (s *create_publication_state) Execute() (State, error) {
 	// dynamically creating the table list to be included in the publication
 	// this would avoid the issue related to partition extention tables. These schemas are getting
 	// changed significantly between versions and the publication would fail if we include them.
-	// Tried using schema name syntax but it does not in older version of postgres
+	// Tried using schema name syntax but it is not supported in the older version of postgres
 	// there are 13.x used by tide in EU prod
 	// After all RDSs are upgraded, we can remove this logic and include schema based publications
 


### PR DESCRIPTION
https://infoblox.atlassian.net/browse/ATLAS-19239 - propagate crossplane error messages to dbclaim
https://infoblox.atlassian.net/browse/ATLAS-19238 - user friendly message when dbversion is not supported
https://infoblox.atlassian.net/browse/ATLAS-19233 - migration failing after 15.3 due to pg_partman issue
https://infoblox.atlassian.net/browse/ATLAS-19201 - migration failing after 15.3 due to pg_cron issue
https://infoblox.atlassian.net/browse/ATLAS-19192 - make dbversion mandatory
https://infoblox.atlassian.net/browse/ATLAS-19193 - set default db at DC