### PR TITLE
fix many types misuses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,11 +137,11 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... --ginkgo.label-filter=!integration -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... --short -coverprofile cover.out
 
 .PHONY: integration-test
 integration-test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -v ./controllers --ginkgo.label-filter=integration -timeout 0 -run ^TestIntegrations$  -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -v ./controllers -timeout 0 -run ^TestIntegrations$  -coverprofile cover.out
 ##@ Build
 
 .PHONY: build

--- a/api/v1/databaseclaim_types.go
+++ b/api/v1/databaseclaim_types.go
@@ -30,9 +30,10 @@ import (
 type DatabaseType string
 
 const (
-	Postgres DatabaseType = "postgres"
-	MySQL    DatabaseType = "mysql"
-	Aurora   DatabaseType = "aurora"
+	Postgres       DatabaseType = "postgres"
+	MySQL          DatabaseType = "mysql"
+	Aurora         DatabaseType = "aurora"
+	AuroraPostgres DatabaseType = "aurora-postgres"
 )
 
 type SQLEngine string

--- a/controllers/databaseclaim_controller_integ_test.go
+++ b/controllers/databaseclaim_controller_integ_test.go
@@ -3,6 +3,8 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"log"
+	"testing"
 
 	crossplanerds "github.com/crossplane-contrib/provider-aws/apis/rds/v1alpha1"
 	"github.com/go-logr/logr"
@@ -10,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/viper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -38,11 +41,15 @@ var _ = Describe("db-controller", func() {
 					Namespace: BDClaimNamespace,
 				},
 				Spec: persistancev1.DatabaseClaimSpec{
-					AppID:         "sample-app",
-					DatabaseName:  "sample_app",
-					InstanceLabel: "sample-connection",
-					SecretName:    "sample-secret",
-					Username:      "sample_user",
+					Class:                 ptr.To(""),
+					AppID:                 "sample-app",
+					DatabaseName:          "sample_app",
+					InstanceLabel:         "sample-connection",
+					SecretName:            "sample-secret",
+					Username:              "sample_user",
+					EnableSuperUser:       ptr.To(false),
+					EnableReplicationRole: ptr.To(false),
+					UseExistingSource:     ptr.To(false),
 				},
 			}
 			Expect(k8sClient.Create(ctx, dbClaim)).Should(Succeed())
@@ -62,6 +69,11 @@ var _ = Describe("manageOperationalTagging", Ordered, func() {
 	dnInstance3 := &crossplanerds.DBInstance{}
 
 	BeforeAll(func() {
+		if testing.Short() {
+			Skip("skipping k8s based tests")
+		}
+		log.Println("FIXME: move integration tests to a separate package kubebuilder uses testing/e2e")
+
 		By("Creating objects beforehand of DBClsuerParameterGroup, DBCluser, DBParameterGroup and DBInstance")
 		testString := "test"
 		ctx := context.Background()
@@ -380,6 +392,9 @@ var _ = Describe("canTagResources", Ordered, func() {
 
 	// Creating resources required to do tests beforehand
 	BeforeAll(func() {
+		if testing.Short() {
+			Skip("skipping k8s based tests")
+		}
 		ctx := context.Background()
 		dbClaim := &persistancev1.DatabaseClaim{
 			TypeMeta: metav1.TypeMeta{

--- a/controllers/databaseclaim_controller_test.go
+++ b/controllers/databaseclaim_controller_test.go
@@ -1231,7 +1231,7 @@ func TestDatabaseClaimReconciler_isClassPermitted(t *testing.T) {
 				Config: tt.reconciler.Config,
 				Class:  tt.reconciler.Class,
 			}
-			got := r.isClassPermitted(tt.args.claimClass)
+			got := isClassPermitted(r.Class, tt.args.claimClass)
 			if got != tt.want {
 				t.Errorf("DatabaseClaimReconciler.isClassPermitted() = %v, want %v", got, tt.want)
 			}

--- a/controllers/databaseclaim_controller_test.go
+++ b/controllers/databaseclaim_controller_test.go
@@ -929,7 +929,7 @@ func TestDatabaseClaimReconcilerGetPasswordRotationTime(t *testing.T) {
 				Config: NewConfig(passwordRotationLess60),
 				Log:    zap.New(zap.UseDevMode(true)),
 			},
-			defaultRotationTime * time.Minute,
+			minRotationTime,
 		},
 		{
 			"Get password rotation time greater 1440 min",
@@ -937,7 +937,7 @@ func TestDatabaseClaimReconcilerGetPasswordRotationTime(t *testing.T) {
 				Config: NewConfig(passwordRotationLess60),
 				Log:    zap.New(zap.UseDevMode(true)),
 			},
-			defaultRotationTime * time.Minute,
+			minRotationTime,
 		},
 	}
 	for _, tt := range tests {

--- a/controllers/dbc_end2end_test.go
+++ b/controllers/dbc_end2end_test.go
@@ -17,8 +17,10 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"strings"
+	"testing"
 	"time"
 
 	persistancev1 "github.com/infobloxopen/db-controller/api/v1"
@@ -57,8 +59,15 @@ var (
 	// class = "default"
 )
 
-var _ = Describe("db-controller end to end testing", Label("integration"), Ordered, func() {
+var _ = Describe("db-controller end to end testing", Ordered, func() {
+
 	var _ = BeforeAll(func() {
+
+		if testing.Short() {
+			Skip("skipping k8s based tests")
+		}
+		log.Println("FIXME: move integration tests to a separate package kubebuilder uses testing/e2e")
+
 		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 		kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -161,8 +161,12 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	err := testEnv.Stop()
+	// FIXME: this hack is fixed in a later version of kubebuilder
 	//  commented that line due to controller-runtime issue: https://github.com/kubernetes-sigs/controller-runtime/issues/1571 Should be reverted later
-	//	Expect(err).ToNot(HaveOccurred())
+	// Expect(err).ToNot(HaveOccurred())
+	if err == nil {
+		return
+	}
 	if err.Error() != "timeout waiting for process kube-apiserver to stop" {
 		Expect(err).ToNot(HaveOccurred())
 	} else {


### PR DESCRIPTION
        it appears constants were leveraged to avoid type checks in Go.
        This resulted in the wrong types on several key API objects which
        will be hard to fix now.

        Address some bad uses of types where possible. int was used in place
        of time.Duration() * time.Minute, causing confusing code.