### PR TITLE
kubectl get dbclaim

### DIFF
--- a/api/v1/databaseclaim_types.go
+++ b/api/v1/databaseclaim_types.go
@@ -335,7 +335,7 @@ type DatabaseClaimConnectionInfo struct {
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.activeDB.DbState`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:printcolumn:name="MigrationState",type="string",priority=1,JSONPath=".status.migrationState"
-// +kubebuilder:resource:shortName=dbc
+// +kubebuilder:resource:shortName=dbc;dbclaim
 // +kubebuilder:subresource:status
 
 // DatabaseClaim is the Schema for the databaseclaims API

--- a/config/crd/bases/persistance.atlas.infoblox.com_databaseclaims.yaml
+++ b/config/crd/bases/persistance.atlas.infoblox.com_databaseclaims.yaml
@@ -14,6 +14,7 @@ spec:
     plural: databaseclaims
     shortNames:
     - dbc
+    - dbclaim
     singular: databaseclaim
   scope: Namespaced
   versions:


### PR DESCRIPTION
Since databaseclaims may sometimes be referred to as dbclaims, this adds an alias to the CRD.