### PR TITLE
PTEUDO-1096 fix more integration tests

### DIFF
--- a/Makefile.infoblox
+++ b/Makefile.infoblox
@@ -85,7 +85,7 @@ build-images: docker-build docker-build-dbproxy docker-build-dsnexec
 # FIXME: remove for a single image
 push-images: docker-push-db-controller docker-push-dbproxy docker-push-dsnexec
 
-.deploy-$(GIT_COMMIT): .id
+.deploy-$(GIT_COMMIT): .id .env
 	@./scripts/check-context.sh
 	helm upgrade --install `cat .id` \
 		db-controller-${CHART_VERSION}.tgz \
@@ -93,6 +93,7 @@ push-images: docker-push-db-controller docker-push-dbproxy docker-push-dsnexec
 		--create-namespace \
 		-f helm/db-controller/minikube.yaml \
 		--set dbController.class=`cat .id` \
+		--set env=`cat .env` \
 		${HELM_SETFLAGS}
 	# Consider removing this, since we dont actually no
 	# helm upgrade is applied in the cluster

--- a/README.md
+++ b/README.md
@@ -115,13 +115,22 @@ limitations under the License.
 
 ### Run integration tests
 
-1. Integration tests run against server box-3. Before running your tests, you'll have to build and deploy to make sure you are running against the latest version.
+1. Integration tests can only be run on box-3.
 
-2. Update file '.id' in the root folder, with a class name of your own (let's say your username). That will be used to create a namespace and the CRDs under it.
-Then run:
-    make docker-build
-    make deploy
+2. If `.id` files causes issues, update it manually. Then, run:
 
-3. if you want to run a single test at a time replace It() by Fit() in the test class, this is a focused test and only this test will run (output shows failure, but this is intended, not to fool you that everything ran successfully)
+    make test-e2e
 
-4. in case the tests failed in the middle, sometimes the resources are not deleted from the AWS account (actually it might takes a long time sometimes). So you can go in there and delete the RDSs that were created. They can be searched for by using the namespace you set in step 2.
+3. If you want to run specific suites, use ginkgo cli:
+
+    cd test/e2e/
+    NAMESPACE=$(cat .id) go test -ginkgo.vv -ginkgo.focus 'AWS'
+
+To run tests without rebuilding the images, and redeploying the chart. Pass NODEPLOY
+
+    cd test/e2e/
+    NODEPLOY=1 NAMESPACE=$(cat .id) go test -ginkgo.vv -ginkgo.focus 'AWS'
+
+4. If you want to run a single test at a time replace It() by Fit() in the test class, this is a focused test and only this test will run (output shows failure, but this is intended, not to fool you that everything ran successfully)
+
+5. in case the tests failed in the middle, sometimes the resources are not deleted from the AWS account (actually it might takes a long time sometimes). So you can go in there and delete the RDSs that were created. They can be searched for by using the namespace you set in step 2.

--- a/api/v1/databaseclaim_types.go
+++ b/api/v1/databaseclaim_types.go
@@ -297,7 +297,8 @@ type Status struct {
 	// The name of the label that was successfully matched against the fragment key names in the db-controller configMap
 	MatchedLabel string `json:"matchLabel,omitempty"`
 
-	ConnectionInfo *DatabaseClaimConnectionInfo `json:"connectionInfo"`
+	// The optional Connection information to the database.
+	ConnectionInfo *DatabaseClaimConnectionInfo `json:"connectionInfo,omitempty"`
 
 	// Version of the provisioned Database
 	DBVersion string `json:"dbversion,omitempty"`
@@ -382,6 +383,9 @@ func init() {
 }
 
 func (c *DatabaseClaimConnectionInfo) Uri() string {
+	if c == nil {
+		return ""
+	}
 	return fmt.Sprintf("%s://%s:%s@%s:%s/%s?sslmode=%s", "postgres",
 		url.QueryEscape(c.Username), url.QueryEscape(c.Password), c.Host, c.Port, url.QueryEscape(c.DatabaseName), c.SSLMode)
 }

--- a/config/crd/bases/persistance.atlas.infoblox.com_databaseclaims.yaml
+++ b/config/crd/bases/persistance.atlas.infoblox.com_databaseclaims.yaml
@@ -294,6 +294,7 @@ spec:
                     description: DbState of the DB. inprogress, "", ready
                     type: string
                   connectionInfo:
+                    description: The optional Connection information to the database.
                     properties:
                       databaseName:
                         type: string
@@ -420,8 +421,6 @@ spec:
                     description: Time the user/password was updated/created
                     format: date-time
                     type: string
-                required:
-                - connectionInfo
                 type: object
               error:
                 description: Any errors related to provisioning this claim.
@@ -438,6 +437,7 @@ spec:
                     description: DbState of the DB. inprogress, "", ready
                     type: string
                   connectionInfo:
+                    description: The optional Connection information to the database.
                     properties:
                       databaseName:
                         type: string
@@ -564,8 +564,6 @@ spec:
                     description: Time the user/password was updated/created
                     format: date-time
                     type: string
-                required:
-                - connectionInfo
                 type: object
               oldDB:
                 description: tracks the DB which is migrated and not more operational

--- a/helm/db-controller/minikube.yaml
+++ b/helm/db-controller/minikube.yaml
@@ -9,4 +9,3 @@ zapLogger:
   level: debug
 dbproxy:
   enabled: false
-env: box-3

--- a/internal/controller/databaseclaim_controller_test.go
+++ b/internal/controller/databaseclaim_controller_test.go
@@ -19,23 +19,19 @@ package controller
 import (
 	"context"
 	"net/url"
-	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	persistancev1 "github.com/infobloxopen/db-controller/api/v1"
-	"github.com/infobloxopen/db-controller/pkg/config"
-	"github.com/infobloxopen/db-controller/pkg/databaseclaim"
 )
 
 var _ = Describe("DatabaseClaim Controller", func() {
@@ -96,7 +92,7 @@ var _ = Describe("DatabaseClaim Controller", func() {
 
 })
 
-var _ = Describe("db-controller", func() {
+var _ = Describe("DatabaseClaim Controller", func() {
 
 	// Define utility constants for object names and testing timeouts/durations and intervals.
 
@@ -117,115 +113,111 @@ var _ = Describe("db-controller", func() {
 		claim := &persistancev1.DatabaseClaim{}
 
 		BeforeEach(func() {
+
+			By("ensuring the resource does not exist")
+			Expect(k8sClient.Get(ctx, typeNamespacedName, claim)).To(HaveOccurred())
+
+			By("creating the custom resource for the Kind DatabaseClaim")
 			parsedDSN, err := url.Parse(testDSN)
 			Expect(err).NotTo(HaveOccurred())
 			password, ok := parsedDSN.User.Password()
 			Expect(ok).To(BeTrue())
 
-			By("creating the custom resource for the Kind DatabaseClaim")
-			err = k8sClient.Get(ctx, typeNamespacedName, claim)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &persistancev1.DatabaseClaim{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "persistance.atlas.infoblox.com/v1",
-						Kind:       "DatabaseClaim",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: "default",
-					},
-					Spec: persistancev1.DatabaseClaimSpec{
-						Class:                 ptr.To(""),
-						AppID:                 "sample-app",
-						DatabaseName:          "sample_app",
-						InstanceLabel:         "sample-connection",
-						SecretName:            secretName,
-						Username:              parsedDSN.User.Username(),
-						EnableSuperUser:       ptr.To(false),
-						EnableReplicationRole: ptr.To(false),
-						UseExistingSource:     ptr.To(false),
-						Type:                  "postgres",
+			Expect(client.IgnoreNotFound(err)).To(Succeed())
+			resource := &persistancev1.DatabaseClaim{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "persistance.atlas.infoblox.com/v1",
+					Kind:       "DatabaseClaim",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: persistancev1.DatabaseClaimSpec{
+					Class:        ptr.To(""),
+					AppID:        "sample-app",
+					DatabaseName: "sample_app",
+					// Dont set this property its for a dead version of db-controller still lurking in this codebase
+					// InstanceLabel:         "sample-connection",
+					SecretName:            secretName,
+					Username:              parsedDSN.User.Username(),
+					EnableSuperUser:       ptr.To(false),
+					EnableReplicationRole: ptr.To(false),
+					UseExistingSource:     ptr.To(false),
+					Type:                  "postgres",
 
-						Port: parsedDSN.Port(),
-						Host: parsedDSN.Hostname(),
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+					Port: parsedDSN.Port(),
+					Host: parsedDSN.Hostname(),
+				},
 			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 			secret := &corev1.Secret{}
 			err = k8sClient.Get(ctx, typeNamespacedSecretName, secret)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      secretName,
-						Namespace: "default",
-					},
-					StringData: map[string]string{
-						"password": password,
-					},
-					Type: "Opaque",
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			Expect(err).To(HaveOccurred())
+			Expect(client.IgnoreNotFound(err)).To(Succeed())
 
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: "default",
+				},
+				StringData: map[string]string{
+					"password": password,
+				},
+				Type: "Opaque",
 			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
 
 		})
 
 		AfterEach(func() {
 			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			By("Cleanup the specific resource instance DatabaseClaim")
 			resource := &persistancev1.DatabaseClaim{}
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			// Reconcile again to finalize the finalizer
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Cleanup the specific resource instance DatabaseClaim")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			By("Ensure the resource is deleted")
+			err = k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).To(HaveOccurred())
+			Expect(client.IgnoreNotFound(err)).To(Succeed())
 
 			secret := &corev1.Secret{}
 			err = k8sClient.Get(ctx, typeNamespacedSecretName, secret)
 			Expect(err).NotTo(HaveOccurred())
-
 			By("Cleanup the database secret")
-
 			Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
 
 		})
 
-		It("Should update DB Claim status", func() {
-
+		It("Should fail to reconcile DB Claim missing dbVersion", func() {
 			By("Reconciling the created resource")
 
-			configPath, err := filepath.Abs(filepath.Join("..", "..", "cmd", "config", "config.yaml"))
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).To(MatchError(".spec.dbVersion is a mandatory field and cannot be empty"))
+			Expect(claim.Status.Error).To(Equal(""))
+		})
+
+		It("Should succeed with no error status to reconcile CR with DBVersion", func() {
+			By("Updating CR with a DB Version")
+
+			resource := &persistancev1.DatabaseClaim{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).NotTo(HaveOccurred())
+			resource.Spec.DBVersion = "13.3"
+			Expect(k8sClient.Update(ctx, resource)).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).NotTo(HaveOccurred())
+			Expect(resource.Spec.DBVersion).To(Equal("13.3"))
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
 			Expect(err).NotTo(HaveOccurred())
-
-			controllerReconciler := &DatabaseClaimReconciler{
-				Config: &databaseclaim.DatabaseClaimConfig{
-					Viper:     config.NewConfig(logger, configPath),
-					Namespace: "default",
-				},
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
-			controllerReconciler.Setup()
-
-			// FIXME: make these actual properties on the reconciler struct
-			controllerReconciler.Config.Viper.Set("defaultMasterusername", "postgres")
-			controllerReconciler.Config.Viper.Set("defaultSslMode", "require")
-
-			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(func() bool {
-				resource := &persistancev1.DatabaseClaim{}
-				err := k8sClient.Get(ctx, typeNamespacedName, resource)
-				if err != nil {
-					return false
-				}
-				return resource.Status.Error == ""
-
-			}, 10*time.Second, 100*time.Millisecond).Should(BeTrue())
+			Expect(resource.Status.Error).To(Equal(""))
 
 		})
 	})

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -84,7 +84,7 @@ func RunDB() (*sql.DB, string, func()) {
 		_ = os.Remove(f.Name())
 		cmd := exec.Command("docker", "rm", "-f", container)
 		cmd.Stderr = os.Stderr
-		// cmd.Stdout = os.Stdout
-		_ = cmd.Run()
+		// Don't wait for it to complete, docker will take 10secs to send a SIGKILL
+		_ = cmd.Start()
 	}
 }

--- a/pkg/databaseclaim/claimstatus.go
+++ b/pkg/databaseclaim/claimstatus.go
@@ -1,0 +1,99 @@
+package databaseclaim
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "github.com/infobloxopen/db-controller/api/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func (r *DatabaseClaimReconciler) manageError(ctx context.Context, dbClaim *v1.DatabaseClaim, inErr error) (ctrl.Result, error) {
+	return manageError(ctx, r.Client, dbClaim, inErr)
+}
+
+type managedErr struct {
+	err error
+}
+
+func (m *managedErr) Error() string {
+	return m.err.Error()
+}
+
+func refreshClaim(ctx context.Context, cli client.Client, claim *v1.DatabaseClaim) error {
+	nname := types.NamespacedName{
+		Namespace: claim.Namespace,
+		Name:      claim.Name,
+	}
+
+	logr := log.FromContext(ctx).WithValues("databaseclaim", nname)
+	if err := cli.Get(ctx, nname, claim); err != nil {
+		logr.Error(err, "refresh_claim")
+		return err
+	}
+
+	return nil
+}
+
+// manageError updates the status of the DatabaseClaim to
+// reflect the error that occurred. It returns the error that
+// should be returned by the Reconcile function.
+func manageError(ctx context.Context, cli client.Client, claim *v1.DatabaseClaim, inErr error) (ctrl.Result, error) {
+
+	nname := types.NamespacedName{
+		Namespace: claim.Namespace,
+		Name:      claim.Name,
+	}
+	logr := log.FromContext(ctx).WithValues("databaseclaim", nname)
+
+	// Prevent manageError being called multiple times on the same error
+	wrappedErr, ok := inErr.(*managedErr)
+	if ok {
+		logr.Error(inErr, fmt.Sprintf("manageError called multiple times on the same error: %#v", inErr))
+	} else {
+		wrappedErr = &managedErr{err: inErr}
+	}
+
+	logr.Error(inErr, "")
+
+	// Refresh the claim to get the latest resource version
+	copy := claim.DeepCopy()
+	if err := refreshClaim(ctx, cli, copy); err != nil {
+		logr.Error(err, "manager_error_refresh_claim")
+		return ctrl.Result{}, wrappedErr
+	}
+
+	copy.Status.Error = inErr.Error()
+	if err := cli.Status().Update(ctx, copy); err != nil {
+		logr.Error(err, "manager_error_update_claim")
+		return ctrl.Result{}, wrappedErr
+	}
+
+	return ctrl.Result{}, wrappedErr
+}
+
+func (r *DatabaseClaimReconciler) manageSuccess(ctx context.Context, dbClaim *v1.DatabaseClaim) (ctrl.Result, error) {
+
+	dbClaim.Status.Error = ""
+
+	if err := r.Client.Status().Update(ctx, dbClaim); err != nil {
+		return ctrl.Result{}, err
+	}
+	//if object is getting deleted then call requeue immediately
+	if !dbClaim.ObjectMeta.DeletionTimestamp.IsZero() {
+		return ctrl.Result{Requeue: true}, nil
+	}
+	if dbClaim.Status.OldDB.DbState == v1.PostMigrationInProgress {
+		return ctrl.Result{RequeueAfter: time.Minute}, nil
+	}
+	return ctrl.Result{RequeueAfter: r.getPasswordRotationTime()}, nil
+}
+
+func (r *DatabaseClaimReconciler) updateClientStatus(ctx context.Context, dbClaim *v1.DatabaseClaim) error {
+
+	return r.Client.Status().Update(ctx, dbClaim)
+}

--- a/pkg/dbclient/client.go
+++ b/pkg/dbclient/client.go
@@ -61,24 +61,10 @@ func New(cfg Config) (Clienter, error) {
 	return newPostgresClient(context.TODO(), cfg)
 }
 
-// DBClientFactory, deprecated don't use
-// Unable to pass database name here, so database name is always "postgres"
-func DBClientFactory(log logr.Logger, dbType, host, port, user, password, sslmode string) (DBClient, error) {
-	log.Error(errors.New("db_client_factory"), "DBClientFactory is deprecated, use New() instead")
-	switch dbType {
-	case PostgresType:
-	}
-	return newPostgresClient(context.TODO(), Config{
-		Log: log,
-		DSN: PostgresConnectionString(host, port, user, password, "postgres", sslmode),
-	})
-}
-
 // creates postgres client
 func newPostgresClient(ctx context.Context, cfg Config) (*client, error) {
 
 	authedDSN := cfg.DSN
-
 	if cfg.UseIAM {
 		var err error
 		authedDSN, err = awsAuthBuilder(ctx, cfg)

--- a/pkg/dbclient/testdb.go
+++ b/pkg/dbclient/testdb.go
@@ -36,9 +36,11 @@ func (t *TestDB) URL() string {
 
 func (t *TestDB) Close() error {
 	fmt.Print("Tearing down dockertest resource of PostgreSQL DB")
-	if err := t.pool.Purge(t.resource); err != nil {
-		fmt.Println("Could not purge resource")
-		return err
+	if t.pool != nil {
+		if err := t.pool.Purge(t.resource); err != nil {
+			fmt.Println("Could not purge resource")
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/hostparams/hostparams.go
+++ b/pkg/hostparams/hostparams.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/crc32"
+	"log"
 	"strconv"
 	"strings"
 
@@ -141,6 +142,8 @@ func New(config *viper.Viper, fragmentKey string, dbClaim *persistancev1.Databas
 		port = dbClaim.Spec.Port
 		hostParams.MaxStorageGB = dbClaim.Spec.MaxStorageGB
 	} else {
+		// change this to a panic after verifying all fragmentKey references are removed
+		log.Println("FIXME: remove all fragment key references")
 		hostParams.MasterUsername = config.GetString(fmt.Sprintf("%s::masterUsername", fragmentKey))
 		hostParams.Engine = config.GetString(fmt.Sprintf("%s::Engine", fragmentKey))
 		hostParams.EngineVersion = config.GetString(fmt.Sprintf("%s::Engineversion", fragmentKey))

--- a/pkg/hostparams/hostparams_test.go
+++ b/pkg/hostparams/hostparams_test.go
@@ -2,7 +2,6 @@ package hostparams
 
 import (
 	"bytes"
-	"flag"
 	"reflect"
 	"testing"
 
@@ -10,19 +9,6 @@ import (
 	persistancev1 "github.com/infobloxopen/db-controller/api/v1"
 	"github.com/spf13/viper"
 )
-
-// The following gingo struct and associted init() is required to run go test with ginkgo related flags
-// Since this test is not using ginkgo, this is a hack to get around the issue of go test complaining about
-// unknown flags.
-var ginkgo struct {
-	dry_run      string
-	label_filter string
-}
-
-func init() {
-	flag.StringVar(&ginkgo.dry_run, "ginkgo.dry-run", "", "Ignore this flag")
-	flag.StringVar(&ginkgo.label_filter, "ginkgo.label-filter", "", "Ignore this flag")
-}
 
 func TestHostParams_Hash(t *testing.T) {
 	type fields struct {

--- a/pkg/roleclaim/roleclaim.go
+++ b/pkg/roleclaim/roleclaim.go
@@ -68,7 +68,7 @@ func (r *DbRoleClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	if permitted := basefun.IsClassPermitted(r.Config.Class, *dbRoleClaim.Spec.Class); !permitted {
-		log.Info("ignoring this claim as this controller does not own this class", "claimClass", *dbRoleClaim.Spec.Class, "controllerClass", r.Config.Class)
+		log.Info("ignoring this claim as this controller does not own this class", "claimclass", *dbRoleClaim.Spec.Class, "ctrlclass", r.Config.Class)
 		return ctrl.Result{}, nil
 	}
 

--- a/test/e2e/databaseclaim_controller_integ_test.go
+++ b/test/e2e/databaseclaim_controller_integ_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"testing"
 	"time"
 
 	crossplanerds "github.com/crossplane-contrib/provider-aws/apis/rds/v1alpha1"
@@ -34,6 +33,7 @@ var _ = Describe("db-controller", func() {
 		It("Should update DB Claim status", func() {
 			By("By creating a new DB Claim")
 			ctx := context.Background()
+			Expect(namespace).NotTo(Equal(""), "you must set the namespace")
 			dbClaim := &persistancev1.DatabaseClaim{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "persistance.atlas.infoblox.com/v1",
@@ -421,107 +421,106 @@ func checkInstanceStatus(k8sClient client.Client, name string, expected bool) {
 
 }
 
-var _ = Describe("canTagResources", Ordered, func() {
-	return
-	// Creating resources required to do tests beforehand
-	BeforeAll(func() {
-		if testing.Short() {
-			Skip("skipping k8s based tests")
-		}
-		ctx := context.Background()
-		dbClaim := &persistancev1.DatabaseClaim{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "persistance.atlas.infoblox.com/v1",
-				Kind:       "DatabaseClaim",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "dbclaim",
-				Namespace: "default",
-			},
-			Spec: persistancev1.DatabaseClaimSpec{
-				AppID:         "sample-app",
-				DatabaseName:  "sample_app",
-				InstanceLabel: "sample-connection-3",
-				SecretName:    "sample-secret",
-				Username:      "sample_user",
-			},
-		}
-		Expect(e2e_k8sClient.Create(ctx, dbClaim)).Should(Succeed())
-		ctx2 := context.Background()
-		dbClaim2 := &persistancev1.DatabaseClaim{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "persistance.atlas.infoblox.com/v1",
-				Kind:       "DatabaseClaim",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "dbclaim-2",
-				Namespace: "default",
-			},
-			Spec: persistancev1.DatabaseClaimSpec{
-				AppID:         "sample-app",
-				DatabaseName:  "sample_app",
-				InstanceLabel: "sample-connection-3",
-				SecretName:    "sample-secret",
-				Username:      "sample_user",
-			},
-		}
-		Expect(e2e_k8sClient.Create(ctx2, dbClaim2)).Should(Succeed())
-	})
+// var _ = Describe("canTagResources", Ordered, func() {
+// 	// Creating resources required to do tests beforehand
+// 	BeforeAll(func() {
+// 		if testing.Short() {
+// 			Skip("skipping k8s based tests")
+// 		}
+// 		ctx := context.Background()
+// 		dbClaim := &persistancev1.DatabaseClaim{
+// 			TypeMeta: metav1.TypeMeta{
+// 				APIVersion: "persistance.atlas.infoblox.com/v1",
+// 				Kind:       "DatabaseClaim",
+// 			},
+// 			ObjectMeta: metav1.ObjectMeta{
+// 				Name:      "dbclaim",
+// 				Namespace: "default",
+// 			},
+// 			Spec: persistancev1.DatabaseClaimSpec{
+// 				AppID:         "sample-app",
+// 				DatabaseName:  "sample_app",
+// 				InstanceLabel: "sample-connection-3",
+// 				SecretName:    "sample-secret",
+// 				Username:      "sample_user",
+// 			},
+// 		}
+// 		Expect(e2e_k8sClient.Create(ctx, dbClaim)).Should(Succeed())
+// 		ctx2 := context.Background()
+// 		dbClaim2 := &persistancev1.DatabaseClaim{
+// 			TypeMeta: metav1.TypeMeta{
+// 				APIVersion: "persistance.atlas.infoblox.com/v1",
+// 				Kind:       "DatabaseClaim",
+// 			},
+// 			ObjectMeta: metav1.ObjectMeta{
+// 				Name:      "dbclaim-2",
+// 				Namespace: "default",
+// 			},
+// 			Spec: persistancev1.DatabaseClaimSpec{
+// 				AppID:         "sample-app",
+// 				DatabaseName:  "sample_app",
+// 				InstanceLabel: "sample-connection-3",
+// 				SecretName:    "sample-secret",
+// 				Username:      "sample_user",
+// 			},
+// 		}
+// 		Expect(e2e_k8sClient.Create(ctx2, dbClaim2)).Should(Succeed())
+// 	})
 
-	Context("Adding tags to DBClaim with empty InstanceLabel", func() {
-		It("Should  permite adding tags", func() {
-			ctx2 := context.Background()
-			dbClaim2 := &persistancev1.DatabaseClaim{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "persistance.atlas.infoblox.com/v1",
-					Kind:       "DatabaseClaim",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "dbclaim-2",
-					Namespace: "default",
-				},
-				Spec: persistancev1.DatabaseClaimSpec{
-					AppID:         "sample-app",
-					DatabaseName:  "sample_app",
-					InstanceLabel: "",
-					SecretName:    "sample-secret",
-					Username:      "sample_user",
-				},
-			}
-			mockReconciler := &controller.DatabaseClaimReconciler{}
-			mockReconciler.Client = e2e_k8sClient
-			check, err2 := databaseclaim.CanTagResources(ctx2, e2e_k8sClient, dbClaim2)
-			Expect(err2).ShouldNot(HaveOccurred())
-			Expect(check).To(BeTrue())
-		})
-	})
+// 	Context("Adding tags to DBClaim with empty InstanceLabel", func() {
+// 		It("Should  permite adding tags", func() {
+// 			ctx2 := context.Background()
+// 			dbClaim2 := &persistancev1.DatabaseClaim{
+// 				TypeMeta: metav1.TypeMeta{
+// 					APIVersion: "persistance.atlas.infoblox.com/v1",
+// 					Kind:       "DatabaseClaim",
+// 				},
+// 				ObjectMeta: metav1.ObjectMeta{
+// 					Name:      "dbclaim-2",
+// 					Namespace: "default",
+// 				},
+// 				Spec: persistancev1.DatabaseClaimSpec{
+// 					AppID:         "sample-app",
+// 					DatabaseName:  "sample_app",
+// 					InstanceLabel: "",
+// 					SecretName:    "sample-secret",
+// 					Username:      "sample_user",
+// 				},
+// 			}
+// 			mockReconciler := &controller.DatabaseClaimReconciler{}
+// 			mockReconciler.Client = k8sClient
+// 			check, err2 := databaseclaim.CanTagResources(ctx2, k8sClient, dbClaim2)
+// 			Expect(err2).ShouldNot(HaveOccurred())
+// 			Expect(check).To(BeTrue())
+// 		})
+// 	})
 
-	Context("Adding tags to DBClaim, When There are already more than one DBClaim exists with similar InstanceLabel", func() {
-		It("Should not permite adding tags", func() {
-			ctx2 := context.Background()
-			dbClaim2 := &persistancev1.DatabaseClaim{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "persistance.atlas.infoblox.com/v1",
-					Kind:       "DatabaseClaim",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "dbclaim-2",
-					Namespace: "default",
-				},
-				Spec: persistancev1.DatabaseClaimSpec{
-					AppID:         "sample-app",
-					DatabaseName:  "sample_app",
-					InstanceLabel: "sample-connection-3",
-					SecretName:    "sample-secret",
-					Username:      "sample_user",
-				},
-			}
-			mockReconciler := &controller.DatabaseClaimReconciler{}
-			mockReconciler.Client = e2e_k8sClient
-			check, err2 := databaseclaim.CanTagResources(ctx2, e2e_k8sClient, dbClaim2)
-			Expect(err2).Should(HaveOccurred())
-			Expect(check).To(BeFalse())
-		})
-	})
+// 	Context("Adding tags to DBClaim, When There are already more than one DBClaim exists with similar InstanceLabel", func() {
+// 		It("Should not permite adding tags", func() {
+// 			ctx2 := context.Background()
+// 			dbClaim2 := &persistancev1.DatabaseClaim{
+// 				TypeMeta: metav1.TypeMeta{
+// 					APIVersion: "persistance.atlas.infoblox.com/v1",
+// 					Kind:       "DatabaseClaim",
+// 				},
+// 				ObjectMeta: metav1.ObjectMeta{
+// 					Name:      "dbclaim-2",
+// 					Namespace: "default",
+// 				},
+// 				Spec: persistancev1.DatabaseClaimSpec{
+// 					AppID:         "sample-app",
+// 					DatabaseName:  "sample_app",
+// 					InstanceLabel: "sample-connection-3",
+// 					SecretName:    "sample-secret",
+// 					Username:      "sample_user",
+// 				},
+// 			}
+// 			mockReconciler := &controller.DatabaseClaimReconciler{}
+// 			mockReconciler.Client = k8sClient
+// 			check, err2 := databaseclaim.CanTagResources(ctx2, k8sClient, dbClaim2)
+// 			Expect(err2).Should(HaveOccurred())
+// 			Expect(check).To(BeFalse())
+// 		})
+// 	})
 
-})
+// })

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -57,7 +57,7 @@ var logger logr.Logger
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	fmt.Fprintf(GinkgoWriter, "Starting E2E suite\n")
-	RunSpecs(t, "e2e suite")
+	RunSpecs(t, "e2e suite", Label("FailFast"))
 	logger = NewGinkgoLogger(t)
 }
 
@@ -89,6 +89,11 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(config.GetConfigOrDie(), client.Options{})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+
+	if len(os.Getenv("NODEPLOY")) > 0 {
+		logger.Info("Skipping deployment")
+		return
+	}
 
 	By("Building image")
 	cmd := exec.Command("make", "build-images")


### PR DESCRIPTION
    - unit test updated to NOT use fragmentKey
    - more unit tests to cover validation errors
    - manageError: fetch fresh claim when writing out error
    - make all status fields including connection info optional
    - refresh claim method, but be careful using it
    - reconcile after deleting object to finalize the finalizer
    - update error status when manageclouddb fails
    - check for double manageError and only log, multiple status updates are happening
    - clean up the dbinstance CRs when the tests are done
    - fix nil pointer error in testdb
    - refresh claim before updating status