### PR TITLE
use github actions for testing and pushing images

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -3,18 +3,13 @@ name: Build and push :main image
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
       with:
@@ -34,7 +29,6 @@ jobs:
         make docker-build
         make docker-build-dbproxy
         make docker-build-dsnexec
-
     - name: Push to GHCR
       env:
         REGISTRY: ghcr.io/${{ github.repository_owner }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on: pull_request
+
+env:
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Setup Go
+      uses: actions/setup-go@v4
+    - name: Setup PostgreSQL
+      uses: tj-actions/install-postgresql@v3
+      with:
+        postgresql-version: 16
+    - name: Test
+      env:
+        REGISTRY: ghcr.io/${{ github.repository_owner }}
+        BUILDKIT_PROGRESS: plain
+      run: |
+        echo 'db-controller-namespace' > .id
+        psql --version
+        make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,5 @@
 /*.tgz
-# Binaries for programs and plugins
-*.exe
-*.exe~
-*.dll
-*.so
-*.dylib
 /bin
-/manager
-/db-controller
 /test/crd
 
 # Test binary, build with `go test -c`
@@ -17,8 +9,7 @@
 *.out
 
 # Kubernetes Generated files - skip generated files, except for vendored files
-vendor
-!vendor/**/zz_generated.*
+/vendor
 
 # editor and IDE paraphernalia
 .idea
@@ -29,8 +20,12 @@ vendor
 # Platform exclusions
 .DS_Store
 
-.id
-
 .vscode
-/.*
+# except github
 /*.properties
+
+# cache files
+/.image*
+/.helms3
+/.env
+/.id

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,72 +4,23 @@ pipeline {
   agent {
     label 'ubuntu_20_04_label'
   }
-  tools {
-    go "Go 1.22.1"
-  }
   stages {
     stage("Setup") {
       steps {
         prepareBuild()
         sh '''
         echo "Setting up the environment"
-        echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
-        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-        sudo apt-get update
-
-        if ! which psql > /dev/null; then
-
-
-          timeout 300 bash -c -- 'while sudo fuser /var/lib/dpkg/lock-frontend > /dev/null 2>&1
-                            do
-                              echo "Waiting to get lock /var/lib/dpkg/lock-frontend..."
-                              sleep 5
-                            done'
-          sudo apt-get install -y postgresql-client-14
-        fi
-
         '''
       }
     }
-    stage("Run tests") {
-      steps {
-        withCredentials([string(credentialsId: 'GITHUB_TOKEN', variable: 'GitHub_PAT')]) {
-            sh "echo machine github.com login $GitHub_PAT > ~/.netrc"
-            sh "echo machine api.github.com login $GitHub_PAT >> ~/.netrc"
-        }
-        sh "echo 'db-controller-name' > .id"
-        sh "psql --version"
-        sh "make test"
-      }
-    }
-    // stage("Build db-controller image") {
-    //   steps {
-    //     withCredentials([string(credentialsId: 'GITHUB_TOKEN', variable: 'GitHub_PAT')]) {
-    //         sh "echo machine github.com login $GitHub_PAT > ~/.netrc"
-    //         sh "echo machine api.github.com login $GitHub_PAT >> ~/.netrc"
-    //     }
-    //     dir("$DIRECTORY") {
-    //       sh """
-    //         echo cicd > .id
-    //         make docker-build
-    //         make docker-build-dbproxy
-    //         make docker-build-dsnexec
-    //       """
-    //     }
-    //   }
-    // }
-    // stage("Push db-controller image") {
-    //   steps {
-    //     withDockerRegistry([credentialsId: "${env.JENKINS_DOCKER_CRED_ID}", url: ""]) {
-    //       dir("$DIRECTORY") {
-    //         sh "REGISTRY=infoblox make docker-push"
-    //         sh "REGISTRY=infoblox make docker-push-dbproxy"
-    //         sh "REGISTRY=infoblox make docker-push-dsnexec"
-    //       }
-    //     }
-    //   }
-    // }
     stage('Push charts') {
+      when {
+        anyOf {
+          branch 'main'
+          branch 'hotfix/*'
+        }
+        expression { !isPrBuild() }
+      }
       steps {
         withAWS(region:'us-east-1', credentials:'CICD_HELM') {
           sh """


### PR DESCRIPTION
    Jenkins has provent to be increasingly unreliable. Move critical
    workflows to Github and only use Jenkins for the bare minimum
    of chart signing.

    Change Jenkins to only push images on commits to main
    Change github actions to only push images when commits to main