### PR TITLE
Remove unused fields from claim

### DIFF
--- a/api/v1/databaseclaim_types.go
+++ b/api/v1/databaseclaim_types.go
@@ -31,8 +31,6 @@ type DatabaseType string
 
 const (
 	Postgres       DatabaseType = "postgres"
-	MySQL          DatabaseType = "mysql"
-	Aurora         DatabaseType = "aurora"
 	AuroraPostgres DatabaseType = "aurora-postgresql"
 )
 
@@ -40,7 +38,6 @@ type SQLEngine string
 
 // SQL database engines.
 const (
-	MysqlEngine      SQLEngine = "mysql"
 	PostgresqlEngine SQLEngine = "postgres"
 )
 
@@ -137,9 +134,6 @@ type DatabaseClaimSpec struct {
 	// +required
 	Type DatabaseType `json:"type"`
 
-	// In most cases the AppID will match the database name. In some cases, however, we will need to provide an optional override.
-	DBNameOverride string `json:"dbNameOverride,omitempty"`
-
 	// Specifies the type of deletion policy to use when the resource is deleted.
 	// It makes a lot of sense to not set it for most cases - this will default it to Orphan based on defaultDeletionPolicy in controllerConfig
 	// If you are setting it to Delete, you should be aware that the database will be deleted when the resource is deleted. Hope you know what you are doing.
@@ -156,14 +150,6 @@ type DatabaseClaimSpec struct {
 
 	// The username that the application will use for accessing the database.
 	Username string `json:"userName"`
-
-	// The optional host name where the database instance is located.
-	// +optional
-	Host string `json:"host,omitempty"`
-
-	// The optional port to use for connecting to the host.
-	// +optional
-	Port string `json:"port,omitempty"`
 
 	// The name of the database.
 	// +required
@@ -189,7 +175,7 @@ type DatabaseClaimSpec struct {
 	// +kubebuilder:validation:Enum=Bronze;Silver;Gold;Platinum
 	BackupPolicy string `json:"backupPolicy,omitempty"`
 
-	// RestoreFrom indicates the snapshot to restore the Database from
+	// RestoreFrom indicates the snapshot id to restore the Database from
 	// +optional
 	RestoreFrom string `json:"restoreFrom,omitempty"`
 

--- a/cmd/config/config.yaml
+++ b/cmd/config/config.yaml
@@ -14,7 +14,7 @@ defaultMinStorageGB: 20
 defaultEngine: postgres
 defaultEngineVersion: 12.11
 defaultMasterPort: 5432
-defaultSslMode: disable
+defaultSslMode: require
 defaultMasterUsername: postgres
 defaultReclaimPolicy: delete
 # For Production this should be false and if SnapShot is not taken it will not be deleted

--- a/cmd/config/config.yaml
+++ b/cmd/config/config.yaml
@@ -14,7 +14,7 @@ defaultMinStorageGB: 20
 defaultEngine: postgres
 defaultEngineVersion: 12.11
 defaultMasterPort: 5432
-defaultSslMode: require
+defaultSslMode: disable
 defaultMasterUsername: postgres
 defaultReclaimPolicy: delete
 # For Production this should be false and if SnapShot is not taken it will not be deleted

--- a/config/crd/bases/persistance.atlas.infoblox.com_databaseclaims.yaml
+++ b/config/crd/bases/persistance.atlas.infoblox.com_databaseclaims.yaml
@@ -75,10 +75,6 @@ spec:
               databaseName:
                 description: The name of the database.
                 type: string
-              dbNameOverride:
-                description: In most cases the AppID will match the database name.
-                  In some cases, however, we will need to provide an optional override.
-                type: string
               dbVersion:
                 description: The version of the database.
                 type: string
@@ -108,10 +104,6 @@ spec:
                   EnableSuperUser will grant rds_superuser and createrole role to Username
                   This value is ignored if {{ .Values.controllerConfig.supportSuperUserElevation }} is set to false
                 type: boolean
-              host:
-                description: The optional host name where the database instance is
-                  located.
-                type: string
               maxStorageGB:
                 description: |-
                   If provided, marks auto storage scalling to true for postgres DBinstance. The value represents the maximum allowed storage to scale upto.
@@ -122,9 +114,6 @@ spec:
                 description: The optional MinStorageGB value requests the minimum
                   database host storage capacity in GBytes
                 type: integer
-              port:
-                description: The optional port to use for connecting to the host.
-                type: string
               preferredMaintenanceWindow:
                 description: |-
                   The weekly time range during which system maintenance can occur.
@@ -155,8 +144,8 @@ spec:
                      * Must be at least 30 minutes.
                 type: string
               restoreFrom:
-                description: RestoreFrom indicates the snapshot to restore the Database
-                  from
+                description: RestoreFrom indicates the snapshot id to restore the
+                  Database from
                 type: string
               secretName:
                 description: The name of the secret to use for storing the ConnectionInfo.  Must

--- a/internal/controller/databaseclaim_controller_test.go
+++ b/internal/controller/databaseclaim_controller_test.go
@@ -84,9 +84,6 @@ var _ = Describe("DatabaseClaim Controller", func() {
 					EnableReplicationRole: ptr.To(false),
 					UseExistingSource:     ptr.To(false),
 					Type:                  "postgres",
-
-					Port: parsedDSN.Port(),
-					Host: parsedDSN.Hostname(),
 				},
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())

--- a/pkg/databaseclaim/databaseclaim.go
+++ b/pkg/databaseclaim/databaseclaim.go
@@ -283,6 +283,7 @@ func (r *DatabaseClaimReconciler) setReqInfo(ctx context.Context, dbClaim *v1.Da
 		return ErrMaxNameLen
 	}
 
+	r.Input.MasterConnInfo.DatabaseName = dbClaim.Spec.DatabaseName
 	r.Input.DbHostIdentifier = r.getDynamicHostName(dbClaim)
 	if basefun.GetSuperUserElevation(r.Config.Viper) {
 		r.Input.EnableSuperUser = *dbClaim.Spec.EnableSuperUser
@@ -667,6 +668,7 @@ func (r *DatabaseClaimReconciler) reconcileNewDB(ctx context.Context, dbClaim *v
 	r.Input.MasterConnInfo.Password = connInfo.Password
 	r.Input.MasterConnInfo.Port = connInfo.Port
 	r.Input.MasterConnInfo.Username = connInfo.Username
+	r.Input.MasterConnInfo.DatabaseName = connInfo.DatabaseName
 
 	dbClient, err := r.getDBClient(ctx, dbClaim)
 	if err != nil {

--- a/pkg/databaseclaim/databaseclaim.go
+++ b/pkg/databaseclaim/databaseclaim.go
@@ -669,6 +669,7 @@ func (r *DatabaseClaimReconciler) reconcileNewDB(ctx context.Context, dbClaim *v
 	r.Input.MasterConnInfo.Port = connInfo.Port
 	r.Input.MasterConnInfo.Username = connInfo.Username
 	r.Input.MasterConnInfo.DatabaseName = dbClaim.Spec.DatabaseName
+	r.Input.MasterConnInfo.SSLMode = basefun.GetDefaultSSLMode(r.Config.Viper)
 
 	dbClient, err := r.getDBClient(ctx, dbClaim)
 	if err != nil {

--- a/pkg/databaseclaim/databaseclaim.go
+++ b/pkg/databaseclaim/databaseclaim.go
@@ -239,7 +239,6 @@ func (r *DatabaseClaimReconciler) setReqInfo(ctx context.Context, dbClaim *v1.Da
 	r.Input = &input{}
 	var (
 		err                     error
-		manageCloudDB           bool
 		sharedDBHost            bool
 		enablePerfInsight       bool
 		cloudwatchLogsExport    []*string
@@ -279,14 +278,12 @@ func (r *DatabaseClaimReconciler) setReqInfo(ctx context.Context, dbClaim *v1.Da
 		BackupRetentionDays:        backupRetentionDays,
 		CACertificateIdentifier:    caCertificateIdentifier,
 	}
-	if manageCloudDB {
-		//check if dbclaim.name is > maxNameLen and if so, error out
-		if len(dbClaim.Name) > maxNameLen {
-			return ErrMaxNameLen
-		}
-
-		r.Input.DbHostIdentifier = r.getDynamicHostName(dbClaim)
+	//check if dbclaim.name is > maxNameLen and if so, error out
+	if len(dbClaim.Name) > maxNameLen {
+		return ErrMaxNameLen
 	}
+
+	r.Input.DbHostIdentifier = r.getDynamicHostName(dbClaim)
 	if basefun.GetSuperUserElevation(r.Config.Viper) {
 		r.Input.EnableSuperUser = *dbClaim.Spec.EnableSuperUser
 	}
@@ -1355,6 +1352,7 @@ func (r *DatabaseClaimReconciler) readResourceSecret(ctx context.Context, secret
 	connInfo.Port = string(rs.Data["port"])
 	connInfo.Username = string(rs.Data["username"])
 	connInfo.Password = string(rs.Data["password"])
+	connInfo.SSLMode = basefun.GetDefaultSSLMode(r.Config.Viper)
 
 	if connInfo.Host == "" ||
 		connInfo.Port == "" ||

--- a/pkg/databaseclaim/databaseclaim.go
+++ b/pkg/databaseclaim/databaseclaim.go
@@ -668,7 +668,7 @@ func (r *DatabaseClaimReconciler) reconcileNewDB(ctx context.Context, dbClaim *v
 	r.Input.MasterConnInfo.Password = connInfo.Password
 	r.Input.MasterConnInfo.Port = connInfo.Port
 	r.Input.MasterConnInfo.Username = connInfo.Username
-	r.Input.MasterConnInfo.DatabaseName = connInfo.DatabaseName
+	r.Input.MasterConnInfo.DatabaseName = dbClaim.Spec.DatabaseName
 
 	dbClient, err := r.getDBClient(ctx, dbClaim)
 	if err != nil {

--- a/pkg/hostparams/hostparams.go
+++ b/pkg/hostparams/hostparams.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
-	persistancev1 "github.com/infobloxopen/db-controller/api/v1"
 	v1 "github.com/infobloxopen/db-controller/api/v1"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -123,7 +122,7 @@ func (p *HostParams) CheckEngineVersion() error {
 	return nil
 }
 
-func New(config *viper.Viper, dbClaim *persistancev1.DatabaseClaim) (*HostParams, error) {
+func New(config *viper.Viper, dbClaim *v1.DatabaseClaim) (*HostParams, error) {
 	var (
 		err   error
 		port  string
@@ -137,12 +136,9 @@ func New(config *viper.Viper, dbClaim *persistancev1.DatabaseClaim) (*HostParams
 	hostParams.EngineVersion = dbClaim.Spec.DBVersion
 	hostParams.Shape = dbClaim.Spec.Shape
 	hostParams.MinStorageGB = dbClaim.Spec.MinStorageGB
-	port = dbClaim.Spec.Port
 	hostParams.MaxStorageGB = dbClaim.Spec.MaxStorageGB
 
-	if port == "" {
-		port = config.GetString("defaultMasterPort")
-	}
+	port = config.GetString("defaultMasterPort")
 	iport, err = strconv.Atoi(port)
 	if err != nil {
 		return nil, fmt.Errorf("invalid master port")
@@ -208,7 +204,7 @@ func New(config *viper.Viper, dbClaim *persistancev1.DatabaseClaim) (*HostParams
 	return &hostParams, nil
 }
 
-func GetActiveHostParams(dbClaim *persistancev1.DatabaseClaim) *HostParams {
+func GetActiveHostParams(dbClaim *v1.DatabaseClaim) *HostParams {
 
 	hostParams := HostParams{}
 

--- a/pkg/hostparams/hostparams_test.go
+++ b/pkg/hostparams/hostparams_test.go
@@ -399,7 +399,6 @@ func TestNew(t *testing.T) {
 			args: args{
 				config: NewConfig(testConfig),
 				dbClaim: &persistancev1.DatabaseClaim{Spec: persistancev1.DatabaseClaimSpec{
-					Port:         "5432",
 					Type:         "aurora-postgresql",
 					DBVersion:    "12.11",
 					Shape:        "db.t4g.medium",
@@ -420,7 +419,6 @@ func TestNew(t *testing.T) {
 			args: args{
 				config: NewConfig(testConfig),
 				dbClaim: &persistancev1.DatabaseClaim{Spec: persistancev1.DatabaseClaimSpec{
-					Port:         "5432",
 					Type:         "aurora-postgresql",
 					DBVersion:    "12.11",
 					Shape:        "db.t4g.medium!io1",
@@ -441,7 +439,6 @@ func TestNew(t *testing.T) {
 			args: args{
 				config: NewConfig(testConfig),
 				dbClaim: &persistancev1.DatabaseClaim{Spec: persistancev1.DatabaseClaimSpec{
-					Port:         "5432",
 					Type:         "postgres",
 					DBVersion:    "12.11",
 					Shape:        "db.t4g.large",
@@ -462,7 +459,6 @@ func TestNew(t *testing.T) {
 			args: args{
 				config: NewConfig(testConfig),
 				dbClaim: &persistancev1.DatabaseClaim{Spec: persistancev1.DatabaseClaimSpec{
-					Port:         "5432",
 					Type:         "aurora-postgresql",
 					DBVersion:    "12.11",
 					Shape:        "db.t4g.medium!xxx",
@@ -492,7 +488,6 @@ func TestNew(t *testing.T) {
 			args: args{
 				config: NewConfig(testConfig),
 				dbClaim: &persistancev1.DatabaseClaim{Spec: persistancev1.DatabaseClaimSpec{
-					Port:         "5432",
 					Type:         "postgres",
 					DBVersion:    "12.11",
 					Shape:        "db.t4g.medium!xxx",
@@ -507,7 +502,6 @@ func TestNew(t *testing.T) {
 			args: args{
 				config: NewConfig(testConfig),
 				dbClaim: &persistancev1.DatabaseClaim{Spec: persistancev1.DatabaseClaimSpec{
-					Port:         "5432",
 					Type:         "postgres",
 					DBVersion:    "12.11",
 					Shape:        "db.t4g.medium!xxx",
@@ -528,7 +522,6 @@ func TestNew(t *testing.T) {
 			args: args{
 				config: NewConfig(testConfig),
 				dbClaim: &persistancev1.DatabaseClaim{Spec: persistancev1.DatabaseClaimSpec{
-					Port:         "5432",
 					Type:         "postgres",
 					DBVersion:    "12.11",
 					Shape:        "db.t4g.medium",
@@ -555,7 +548,6 @@ func TestNew(t *testing.T) {
 			args: args{
 				config: NewConfig(testConfig),
 				dbClaim: &persistancev1.DatabaseClaim{Spec: persistancev1.DatabaseClaimSpec{
-					Port:         "5432",
 					Type:         "postgres",
 					DBVersion:    "12.11",
 					Shape:        "db.t4g.medium!xxx",
@@ -577,7 +569,6 @@ func TestNew(t *testing.T) {
 			args: args{
 				config: NewConfig(testConfig),
 				dbClaim: &persistancev1.DatabaseClaim{Spec: persistancev1.DatabaseClaimSpec{
-					Port:         "5432",
 					Type:         "postgres",
 					DBVersion:    "12.11",
 					Shape:        "db.t4g.medium",
@@ -606,7 +597,6 @@ func TestNew(t *testing.T) {
 			args: args{
 				config: NewConfig(testConfig),
 				dbClaim: &persistancev1.DatabaseClaim{Spec: persistancev1.DatabaseClaimSpec{
-					Port:         "5432",
 					Type:         "postgres",
 					DBVersion:    "12.11",
 					Shape:        "db.t4g.medium!xxx",
@@ -651,7 +641,6 @@ func TestDeletionPolicy(t *testing.T) {
 			args: args{
 				config: NewConfig(testConfig),
 				dbClaim: &persistancev1.DatabaseClaim{Spec: persistancev1.DatabaseClaimSpec{
-					Port:         "5432",
 					Type:         "aurora-postgresql",
 					DBVersion:    "12.11",
 					Shape:        "db.t4g.medium",
@@ -665,7 +654,6 @@ func TestDeletionPolicy(t *testing.T) {
 			args: args{
 				config: NewConfig(testConfig),
 				dbClaim: &persistancev1.DatabaseClaim{Spec: persistancev1.DatabaseClaimSpec{
-					Port:           "5432",
 					Type:           "aurora-postgresql",
 					DBVersion:      "12.11",
 					Shape:          "db.t4g.medium",
@@ -680,7 +668,6 @@ func TestDeletionPolicy(t *testing.T) {
 			args: args{
 				config: NewConfig(testConfig),
 				dbClaim: &persistancev1.DatabaseClaim{Spec: persistancev1.DatabaseClaimSpec{
-					Port:           "5432",
 					Type:           "postgres",
 					DBVersion:      "12.11",
 					Shape:          "db.t4g.medium",
@@ -715,7 +702,6 @@ func TestCheckEngineVersion(t *testing.T) {
 			args: args{
 				config: NewConfig(testConfig),
 				dbClaim: &persistancev1.DatabaseClaim{Spec: persistancev1.DatabaseClaimSpec{
-					Port:         "5432",
 					Type:         "aurora-postgresql",
 					Shape:        "db.t4g.medium",
 					MinStorageGB: 20,
@@ -728,7 +714,6 @@ func TestCheckEngineVersion(t *testing.T) {
 			args: args{
 				config: NewConfig(testConfig),
 				dbClaim: &persistancev1.DatabaseClaim{Spec: persistancev1.DatabaseClaimSpec{
-					Port:         "5432",
 					Type:         "aurora-postgresql",
 					DBVersion:    "12.11",
 					Shape:        "db.t4g.medium",

--- a/pkg/roleclaim/roleclaim.go
+++ b/pkg/roleclaim/roleclaim.go
@@ -291,8 +291,6 @@ func (r *DbRoleClaimReconciler) readResourceSecret(ctx context.Context, dbcBaseC
 	}
 
 	connInfo.DatabaseName = dbClaim.Spec.DatabaseName
-	connInfo.SSLMode = basefun.GetDefaultSSLMode(r.Config.Viper)
-
 	connInfo.Host = string(rs.Data["endpoint"])
 	connInfo.Port = string(rs.Data["port"])
 	connInfo.Username = string(rs.Data["username"])

--- a/pkg/roleclaim/roleclaim.go
+++ b/pkg/roleclaim/roleclaim.go
@@ -297,6 +297,7 @@ func (r *DbRoleClaimReconciler) readResourceSecret(ctx context.Context, dbcBaseC
 	connInfo.Port = string(rs.Data["port"])
 	connInfo.Username = string(rs.Data["username"])
 	connInfo.Password = string(rs.Data["password"])
+	connInfo.SSLMode = basefun.GetDefaultSSLMode(r.Config.Viper)
 
 	if connInfo.Host == "" ||
 		connInfo.Port == "" ||

--- a/test/e2e/dbc_end2end_test.go
+++ b/test/e2e/dbc_end2end_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strings"
 	"time"
 
 	crossplanerds "github.com/crossplane-contrib/provider-aws/apis/rds/v1alpha1"
@@ -569,55 +568,55 @@ var _ = Describe("AWS", Ordered, func() {
 
 	var _ = AfterAll(func() {
 
-		//delete DBRoleClaims within this namespace
-		dbRoleClaims := &v1.DbRoleClaimList{}
-		if err := k8sClient.List(ctx, dbRoleClaims, client.InNamespace(namespace)); err != nil {
-			Expect(err).To(BeNil())
-		}
-		for _, dbrc := range dbRoleClaims.Items {
-			By("Deleting DBRoleClaim: " + dbrc.Name)
-			k8sClient.Delete(ctx, &dbrc)
-		}
+		// //delete DBRoleClaims within this namespace
+		// dbRoleClaims := &v1.DbRoleClaimList{}
+		// if err := k8sClient.List(ctx, dbRoleClaims, client.InNamespace(namespace)); err != nil {
+		// 	Expect(err).To(BeNil())
+		// }
+		// for _, dbrc := range dbRoleClaims.Items {
+		// 	By("Deleting DBRoleClaim: " + dbrc.Name)
+		// 	k8sClient.Delete(ctx, &dbrc)
+		// }
 
-		// delete DBClaims within this namespace
-		dbClaims := &v1.DatabaseClaimList{}
-		if err := k8sClient.List(ctx, dbClaims, client.InNamespace(namespace)); err != nil {
-			Expect(err).To(BeNil())
-		}
-		for _, dbc := range dbClaims.Items {
-			By("Deleting DatabaseClaim: " + dbc.Name)
-			k8sClient.Delete(ctx, &dbc)
-		}
+		// // delete DBClaims within this namespace
+		// dbClaims := &v1.DatabaseClaimList{}
+		// if err := k8sClient.List(ctx, dbClaims, client.InNamespace(namespace)); err != nil {
+		// 	Expect(err).To(BeNil())
+		// }
+		// for _, dbc := range dbClaims.Items {
+		// 	By("Deleting DatabaseClaim: " + dbc.Name)
+		// 	k8sClient.Delete(ctx, &dbc)
+		// }
 
-		// delete DBClaims within this namespace
-		dbinstances := &crossplanerds.DBInstanceList{}
-		if err := k8sClient.List(ctx, dbinstances, &client.ListOptions{}); err != nil {
-			Expect(err).To(BeNil())
-		}
-		for _, dbinstance := range dbinstances.Items {
-			if strings.Contains(dbinstance.Name, namespace) {
-				By("Deleting DBInstance: " + dbinstance.Name)
-				k8sClient.Delete(ctx, &dbinstance)
-			}
-		}
+		// // delete DBClaims within this namespace
+		// dbinstances := &crossplanerds.DBInstanceList{}
+		// if err := k8sClient.List(ctx, dbinstances, &client.ListOptions{}); err != nil {
+		// 	Expect(err).To(BeNil())
+		// }
+		// for _, dbinstance := range dbinstances.Items {
+		// 	if strings.Contains(dbinstance.Name, namespace) {
+		// 		By("Deleting DBInstance: " + dbinstance.Name)
+		// 		k8sClient.Delete(ctx, &dbinstance)
+		// 	}
+		// }
 
-		// delete Secrets within this namespace
-		secrets := &corev1.SecretList{}
-		if err := k8sClient.List(ctx, secrets, client.InNamespace(namespace)); err != nil {
-			Expect(err).To(BeNil())
-		}
-		for _, secret := range secrets.Items {
-			By("Deleting Secret: " + secret.Name)
-			k8sClient.Delete(ctx, &secret)
-		}
+		// // delete Secrets within this namespace
+		// secrets := &corev1.SecretList{}
+		// if err := k8sClient.List(ctx, secrets, client.InNamespace(namespace)); err != nil {
+		// 	Expect(err).To(BeNil())
+		// }
+		// for _, secret := range secrets.Items {
+		// 	By("Deleting Secret: " + secret.Name)
+		// 	k8sClient.Delete(ctx, &secret)
+		// }
 
-		//delete the namespace
-		By("deleting the namespace")
-		k8sClient.Delete(ctx, &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: namespace,
-			},
-		})
+		// //delete the namespace
+		// By("deleting the namespace")
+		// k8sClient.Delete(ctx, &corev1.Namespace{
+		// 	ObjectMeta: metav1.ObjectMeta{
+		// 		Name: namespace,
+		// 	},
+		// })
 
 	})
 })


### PR DESCRIPTION
These fields were used in case a dbinstance was used. As this feature was removed, these fields are no longer valid.