### PR TITLE
ensure only one db-controller attempts to mutate pod

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -178,6 +178,7 @@ func main() {
 		MetricsConfigYamlPath: metricsConfigYamlPath,
 	}
 
+	setupLog.Info("setup_ctrl", "dbClaimConfig", dbClaimConfig)
 	if err = (&controller.DatabaseClaimReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),

--- a/helm/db-controller/minikube.yaml
+++ b/helm/db-controller/minikube.yaml
@@ -4,6 +4,8 @@ controllerConfig:
   dbSubnetGroupNameRef: box-3
   providerConfig: box-3
   caCertificateIdentifier: "rds-ca-rsa2048-g1"
+  passwordConfig:
+    passwordRotationPeriod: 3m
 zapLogger:
   develMode: true
   level: debug

--- a/helm/db-controller/templates/mutatingwebhookconfiguration.yaml
+++ b/helm/db-controller/templates/mutatingwebhookconfiguration.yaml
@@ -21,6 +21,11 @@ webhooks:
     matchExpressions:
       - key: "persistance.atlas.infoblox.com/databaseclaim"
         operator: "Exists"
+        # Important to prevent multiple db-controllers from stepping on each other
+      - key: "persistance.atlas.infoblox.com/class"
+        operator: "In"
+        values:
+            - {{ .Values.dbController.class | quote }}
   rules:
   - apiGroups:
     - ""

--- a/helm/db-controller/templates/test/dbproxy.yaml
+++ b/helm/db-controller/templates/test/dbproxy.yaml
@@ -80,6 +80,7 @@ metadata:
   labels:
     {{- include "db-controller.labels" . | nindent 4 }}
     persistance.atlas.infoblox.com/databaseclaim: {{ .Release.Name }}-dbproxy-test
+    persistance.atlas.infoblox.com/class: {{ .Values.dbController.class | quote }}
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/helm/db-controller/values.yaml
+++ b/helm/db-controller/values.yaml
@@ -146,7 +146,7 @@ controllerConfig:
   passwordConfig:
     passwordComplexity: enabled
     minPasswordLength: 15
-    passwordRotationPeriod: 60
+    passwordRotationPeriod: 60m
   pgTemp: "/pg-temp/"
   region: us-east-1
   storageType: gp3

--- a/internal/controller/databaseclaim_controller.go
+++ b/internal/controller/databaseclaim_controller.go
@@ -87,6 +87,7 @@ func (r *DatabaseClaimReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
+		// Ignore status updates in objects being watched
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		For(&persistancev1.DatabaseClaim{}).
 		Complete(r)

--- a/internal/controller/databaseclaim_controller.go
+++ b/internal/controller/databaseclaim_controller.go
@@ -18,11 +18,13 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	persistancev1 "github.com/infobloxopen/db-controller/api/v1"
 	"github.com/infobloxopen/db-controller/pkg/databaseclaim"
@@ -57,9 +59,11 @@ func (r *DatabaseClaimReconciler) Reconciler() *databaseclaim.DatabaseClaimRecon
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.18.2/pkg/reconcile
 func (r *DatabaseClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
-	return r.reconciler.Reconcile(ctx, req)
+	res, err := r.reconciler.Reconcile(ctx, req)
+	logger.V(1).Info("reconcile_done", "err", err, "res", res)
+	return res, err
 }
 
 func (r *DatabaseClaimReconciler) Setup() {
@@ -74,7 +78,16 @@ func (r *DatabaseClaimReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	r.Setup()
 
+	if r.Config == nil {
+		return fmt.Errorf("DatabaseClaimConfig is not set")
+	}
+
+	if r.Client == nil {
+		return fmt.Errorf("client is not set")
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		For(&persistancev1.DatabaseClaim{}).
 		Complete(r)
 }

--- a/pkg/basefunctions/basefunctions.go
+++ b/pkg/basefunctions/basefunctions.go
@@ -13,21 +13,11 @@ import (
 )
 
 var (
-	minRotationTime = 60 * time.Minute // rotation time in minutes
-	maxRotationTime = 1440 * time.Minute
-	maxWaitTime     = 10 * time.Minute
-	defaultPassLen  = 32
-	defaultNumDig   = 10
-	defaultNumSimb  = 10
+	maxWaitTime    = 10 * time.Minute
+	defaultPassLen = 32
+	defaultNumDig  = 10
+	defaultNumSimb = 10
 )
-
-func GetMinRotationTime() time.Duration {
-	return minRotationTime
-}
-
-func GetMaxRotationTime() time.Duration {
-	return maxRotationTime
-}
 
 func GetMaxWaitTime() time.Duration {
 	return maxWaitTime
@@ -169,8 +159,8 @@ func GetSuperUserElevation(viperConfig *viper.Viper) bool {
 	return viperConfig.GetBool("supportSuperUserElevation")
 }
 
-func GetPasswordRotationPeriod(viperConfig *viper.Viper) int {
-	return viperConfig.GetInt("passwordconfig::passwordRotationPeriod")
+func GetPasswordRotationPeriod(viperConfig *viper.Viper) time.Duration {
+	return viperConfig.GetDuration("passwordconfig::passwordRotationPeriod")
 }
 
 func GetBackupRetentionDays(viperConfig *viper.Viper) int64 {

--- a/pkg/databaseclaim/claimstatus.go
+++ b/pkg/databaseclaim/claimstatus.go
@@ -2,6 +2,7 @@ package databaseclaim
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -13,6 +14,11 @@ import (
 )
 
 func (r *DatabaseClaimReconciler) manageError(ctx context.Context, dbClaim *v1.DatabaseClaim, inErr error) (ctrl.Result, error) {
+	// Class of errors that should stop the reconciliation loop
+	// but not cause a status change on the CR
+	if errors.Is(inErr, ErrDoNotUpdateStatus) {
+		return ctrl.Result{}, nil
+	}
 	return manageError(ctx, r.Client, dbClaim, inErr)
 }
 

--- a/pkg/roleclaim/roleclaim.go
+++ b/pkg/roleclaim/roleclaim.go
@@ -442,14 +442,7 @@ func createRole(dbClient dbclient.Clienter, roleName string, log *logr.Logger, d
 }
 
 func (r *DbRoleClaimReconciler) getPasswordRotationTime() time.Duration {
-	prt := time.Duration(basefun.GetPasswordRotationPeriod(r.Config.Viper)) * time.Minute
-
-	if prt < basefun.GetMinRotationTime() || prt > basefun.GetMaxRotationTime() {
-		log.Log.Info("password rotation time is out of range, should be between 60 and 1440 min, use the default")
-		return basefun.GetMinRotationTime()
-	}
-
-	return prt
+	return basefun.GetPasswordRotationPeriod(r.Config.Viper)
 }
 
 func (r *DbRoleClaimReconciler) updateClientStatus(ctx context.Context, schemaUserClaim *v1.DbRoleClaim) error {


### PR DESCRIPTION
    introduce a mandatory class based label to mutate pods
    add a liveness probe to the sidecar
    get rid of these compiled min and max rotation values
    exit existing db reconciliation when nothing needs to happen
    add status predicate event filter to databaseclaim reconciler