### PR TITLE
use unique component in deployment yaml

### DIFF
--- a/helm/db-controller/templates/deployment.yaml
+++ b/helm/db-controller/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "db-controller.labels" . | nindent 4 }}
+    app.kubernetes.io/component: manager
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -12,6 +13,7 @@ spec:
   selector:
     matchLabels:
       {{- include "db-controller.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: manager
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -20,6 +22,7 @@ spec:
       {{- end }}
       labels:
         {{- include "db-controller.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: manager
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/db-controller/templates/test/dbproxy.yaml
+++ b/helm/db-controller/templates/test/dbproxy.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "db-controller.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dbproxy-test
   annotations:
     "helm.sh/hook": "test"
 ---

--- a/scripts/psql-open-owners.sh
+++ b/scripts/psql-open-owners.sh
@@ -24,7 +24,7 @@ get_table_owners() {
     printf "Created: $(kubectl get databaseclaim "$claim_name" -n "$namespace" -o jsonpath='{.metadata.creationTimestamp}')\n"
     printf "Secret: $(kubectl get databaseclaim "$claim_name" -n "$namespace" -o jsonpath='{.spec.secretName}')\n"
     # Run psql command to find the owner of tables
-    kubectl exec deploy/db-controller -n db-controller -c postgres -- psql "$dsn" -c '\dt' \
+    kubectl exec deploy/db-controller -n db-controller -c manager -- psql "$dsn" -c '\dt' \
         | awk '{if(NR>2 && $4!="")print $7}' | sort | uniq -c | sort -nr
 }
 


### PR DESCRIPTION
breaking change in deployment yaml. deployment has to be recreated for this to take effect

DEMO
modified to access `dwells` for demo
```
./scripts/psql-open-owners.sh identity/identity-api

Namespace: identity
DatabaseClaim: identity-api
Created: 2024-01-12T14:25:38Z
Secret: identity-api-dsn
     14 identity-api
```