### PR TITLE
add active db version to printer column

### DIFF
--- a/api/v1/databaseclaim_types.go
+++ b/api/v1/databaseclaim_types.go
@@ -310,9 +310,10 @@ type DatabaseClaimConnectionInfo struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:printcolumn:name="DB",type=string,JSONPath=`.spec.databaseName`
+// +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.activeDB.dbversion"
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.activeDB.DbState`
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`
+// +kubebuilder:printcolumn:name="Age",type="date",priority=1,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:printcolumn:name="MigrationState",type="string",priority=1,JSONPath=".status.migrationState"
 // +kubebuilder:resource:shortName=dbc
 // +kubebuilder:subresource:status

--- a/config/crd/bases/persistance.atlas.infoblox.com_databaseclaims.yaml
+++ b/config/crd/bases/persistance.atlas.infoblox.com_databaseclaims.yaml
@@ -17,14 +17,18 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.databaseName
-      name: DB
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .status.activeDB.dbversion
+      name: Version
       type: string
     - jsonPath: .status.activeDB.DbState
       name: State
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
+      priority: 1
       type: date
     - jsonPath: .status.migrationState
       name: MigrationState


### PR DESCRIPTION
DEMO
```
db-controller ❯ k get dbc -n usergroups usergroups-dbapi -o wide
NAME               TYPE       VERSION   STATE   AGE    MIGRATIONSTATE
usergroups-dbapi   postgres   15.5      ready   316d   completed

db-controller ❯ k get dbc -n usergroups usergroups-dbapi
NAME               TYPE       VERSION   STATE
usergroups-dbapi   postgres   15.5      ready
```