### PR TITLE
put xrd in the templates folder and turn off pruning

### DIFF
--- a/helm/db-controller/templates/xrd.yaml
+++ b/helm/db-controller/templates/xrd.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
   name: xnetworkrecords.persistance.infoblox.com
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   group: persistance.infoblox.com
   names:


### PR DESCRIPTION
Authz depends on db-controller-crds (at a minimum). Since XRD requires crossplane CRDs to be installed (which is complex), moving this back to db-controller chart.

Fixes this issue
```
db-controller-crds   328d   False   Helm upgrade failed: failed to apply CRD no CompositeResourceDefinition with the name "xnetworkrecords.persistance.infoblox.com" found
```

Related: https://github.com/Infoblox-CTO/deployment-configurations/pull/63292