### PR TITLE
PTEUDO-1562 rewrite migration logic of controller

### DIFF
--- a/api/v1/databaseclaim_types.go
+++ b/api/v1/databaseclaim_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -339,6 +340,24 @@ type DatabaseClaimList struct {
 
 func init() {
 	SchemeBuilder.Register(&DatabaseClaim{}, &DatabaseClaimList{})
+}
+
+// Validate checks for basic errors in the DSN string
+func (c *DatabaseClaimConnectionInfo) Validate() error {
+	if c.Host == "" {
+		return errors.New("dsn has an empty host")
+	}
+	if c.Username == "" {
+		return errors.New("dsn has an empty user")
+	}
+	if c.Password == "" {
+		return errors.New("dsn has an empty password")
+	}
+	if c.DatabaseName == "" {
+		return errors.New("dsn has an empty database name")
+	}
+
+	return nil
 }
 
 func (c *DatabaseClaimConnectionInfo) Uri() string {

--- a/cmd/config/config.yaml
+++ b/cmd/config/config.yaml
@@ -1,3 +1,4 @@
+env: "testenv"
 athena-shared:
   masterUsername: root
 authSource: secret
@@ -41,9 +42,7 @@ passwordConfig:
   passwordRotationPeriod: 60
 
 systemFunctions:
-  ib_realm: "{{ .Values.ib.realm }}"
-  ib_env: "{{ .Values.env }}"
-  ib_lifecycle: "{{ .Values.lifecycle }}"
-  
-
+  ib_realm: "ib_realm"
+  ib_env: "ib_env"
+  ib_lifecycle: "ib_lifecycle"
 

--- a/helm/db-controller/templates/tests/dbproxy.yaml
+++ b/helm/db-controller/templates/tests/dbproxy.yaml
@@ -74,6 +74,7 @@ metadata:
   annotations:
     # ensure this runs on the new db-controller, not the existing one
     "helm.sh/hook": "test"
+    "helm.sh/hook-weight": "-5"
 spec:
   class: {{ .Values.dbController.class }}
   databaseName: mydb
@@ -159,10 +160,10 @@ spec:
               echo "Connection successful!"
               exit 0
             fi
-            echo "Failed to connect. Retrying in 5 seconds..."
-            sleep 5
+            echo "Failed to connect. Retrying in 1 second..."
+            sleep 1
           done
-          echo "Failed to connect after 20 attempts. Exiting."
+          echo "Failed to connect after 50 attempts. Exiting."
           exit 1
       volumeMounts:
         - name: dsn-volume
@@ -187,8 +188,7 @@ spec:
           kill -s INT $(pidof /usr/bin/dbproxy)
           exit 0
   shareProcessNamespace: true
-  # Sidecar has a liveness probe, allow it to restart
-  restartPolicy: Never
+  restartPolicy: OnFailure
   volumes:
     - name: dsn-volume
       secret:

--- a/helm/db-controller/templates/tests/dsnexec.yaml
+++ b/helm/db-controller/templates/tests/dsnexec.yaml
@@ -13,7 +13,7 @@ metadata:
     persistance.atlas.infoblox.com/dsnexec-config: {{ .Release.Name }}-dsnexec-config
   annotations:
     helm.sh/hook: test
-    helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded"
+    # helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded"
 spec:
   serviceAccountName: {{ .Release.Name }}-dbproxy-test
   initContainers:
@@ -66,14 +66,22 @@ spec:
 
           # Loop for 1 minute (60 seconds)
           while [ $(($(date +%s) - start_time)) -lt 60 ]; do
-
+              echo >2 "list processes"
+              ls /proc | grep '^[0-9]'
+              # Fallback to grep when pidof fails
               if check_table_exists; then
                   echo "Table $TABLE_NAME exists!"
-                  kill -s INT $(pidof dsnexec)
+                  PID=$(pidof dsnexec)
+                  if [ -n "$PID" ]; then
+                    echo "Killing dsnexec..."
+                    kill -s INT $PID
+                  else
+                    echo "dsnexec not running..."
+                  fi
                   exit 0
               else
-                  echo "Table $TABLE_NAME does not exist. Checking again in 5 seconds..."
-                  sleep 5
+                  echo "Table $TABLE_NAME does not exist. Checking again in 2 seconds..."
+                  sleep 1
               fi
           done
 
@@ -83,8 +91,7 @@ spec:
           mountPath: /etc/secrets
           readOnly: true
   shareProcessNamespace: true
-  # Sidecar has a liveness probe, allow it to restart
-  restartPolicy: Never
+  restartPolicy: OnFailure
   volumes:
     - name: dsn-volume
       secret:

--- a/internal/controller/databaseclaim_controller.go
+++ b/internal/controller/databaseclaim_controller.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	persistancev1 "github.com/infobloxopen/db-controller/api/v1"
@@ -63,18 +62,11 @@ func (r *DatabaseClaimReconciler) Reconciler() *databaseclaim.DatabaseClaimRecon
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.18.2/pkg/reconcile
 func (r *DatabaseClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
-
-	res, err := r.reconciler.Reconcile(ctx, req)
-	logger.V(debugLevel).Info("reconcile_done", "err", err, "res", res)
-	return res, err
+	return r.reconciler.Reconcile(ctx, req)
 }
 
 func (r *DatabaseClaimReconciler) Setup() {
-	r.reconciler = &databaseclaim.DatabaseClaimReconciler{
-		Client: r.Client,
-		Config: r.Config,
-	}
+	r.reconciler = databaseclaim.New(r.Client, r.Config)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/databaseclaim_controller_tagging_test.go
+++ b/internal/controller/databaseclaim_controller_tagging_test.go
@@ -21,6 +21,7 @@ var hasOperationalTag = databaseclaim.HasOperationalTag
 
 var _ = Describe("Tagging", Ordered, func() {
 
+	var logger = NewGinkgoLogger()
 	// define and create objects in the test cluster
 
 	name := fmt.Sprintf("test-%s-%s", namespace, rand.String(5))

--- a/internal/controller/databaseclaim_controller_test.go
+++ b/internal/controller/databaseclaim_controller_test.go
@@ -198,6 +198,7 @@ var _ = Describe("DatabaseClaim Controller", func() {
 
 		It("dbproxy mutated pod", func() {
 
+			class := "testenv"
 			// FIXME: can this be done without standing up
 			// a full manager?
 			mgr, err := manager.New(cfg, manager.Options{
@@ -213,7 +214,7 @@ var _ = Describe("DatabaseClaim Controller", func() {
 
 			Expect(mutating.SetupWebhookWithManager(mgr, mutating.SetupConfig{
 				Namespace:  namespace,
-				Class:      env,
+				Class:      class,
 				DBProxyImg: "test-db-proxy:latest",
 				DSNExecImg: "test-dsn-exec:latest",
 			})).To(Succeed())
@@ -235,7 +236,7 @@ var _ = Describe("DatabaseClaim Controller", func() {
 					Labels: map[string]string{
 						mutating.LabelCheckProxy: "enabled",
 						mutating.LabelClaim:      resourceName,
-						mutating.LabelClass:      env,
+						mutating.LabelClass:      class,
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/internal/controller/databasecontroller_migrate_test.go
+++ b/internal/controller/databasecontroller_migrate_test.go
@@ -1,0 +1,305 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	persistancev1 "github.com/infobloxopen/db-controller/api/v1"
+	"github.com/infobloxopen/db-controller/internal/dockerdb"
+	"github.com/infobloxopen/db-controller/pkg/hostparams"
+	"github.com/infobloxopen/db-controller/pkg/pgctl"
+)
+
+var _ = Describe("claim migrate", func() {
+
+	// Define utility constants for object names and testing timeouts/durations and intervals.
+
+	var (
+		ctxLogger context.Context
+		cancel    func()
+		success   = ctrl.Result{Requeue: false, RequeueAfter: 60}
+	)
+
+	BeforeEach(func() {
+		ctxLogger, cancel = context.WithCancel(context.Background())
+		ctxLogger = log.IntoContext(ctxLogger, NewGinkgoLogger())
+
+		Expect(ctxLogger).ToNot(BeNil())
+
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	Context("Setup DB Claim", func() {
+
+		const resourceName = "migrate-dbclaim"
+		// secret to store the dsn for claims
+		const claimSecretName = "migrate-dbclaim-creds"
+		// master creds to source db
+		const sourceSecretName = "postgres-source"
+		// master creds to target db
+		// const targetSecretName = "postgres-target"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+		typeNamespacedClaimSecretName := types.NamespacedName{
+			Name:      claimSecretName,
+			Namespace: "default",
+		}
+		typeNamespacedSourceSecretName := types.NamespacedName{
+			Name:      sourceSecretName,
+			Namespace: "default",
+		}
+		// typeNamespacedTargetSecretName := types.NamespacedName{
+		// 	Name:      targetSecretName,
+		// 	Namespace: "default",
+		// }
+
+		claim := &persistancev1.DatabaseClaim{}
+
+		kctx := context.Background()
+
+		BeforeEach(func() {
+
+			By("ensuring the resource does not exist")
+			Expect(k8sClient.Get(kctx, typeNamespacedName, claim)).To(HaveOccurred())
+
+			By("creating the custom resource for the Kind DatabaseClaim")
+			parsedDSN, err := url.Parse(testDSN)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.IgnoreNotFound(err)).To(Succeed())
+
+			resource := &persistancev1.DatabaseClaim{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "persistance.atlas.infoblox.com/v1",
+					Kind:       "DatabaseClaim",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: persistancev1.DatabaseClaimSpec{
+					Class:                 ptr.To(""),
+					DatabaseName:          "postgres",
+					SecretName:            claimSecretName,
+					EnableSuperUser:       ptr.To(false),
+					EnableReplicationRole: ptr.To(false),
+					UseExistingSource:     ptr.To(true),
+					Type:                  "postgres",
+					SourceDataFrom: &persistancev1.SourceDataFrom{
+						Type: "database",
+						Database: &persistancev1.Database{
+							SecretRef: &persistancev1.SecretRef{
+								Name:      sourceSecretName,
+								Namespace: "default",
+							},
+						},
+					},
+					Username: parsedDSN.User.Username(),
+				},
+			}
+			Expect(k8sClient.Create(kctx, resource)).To(Succeed())
+
+			By("Creating the source master creds")
+			srcSecret := &corev1.Secret{}
+			err = k8sClient.Get(ctxLogger, typeNamespacedSourceSecretName, srcSecret)
+			Expect(err).To(HaveOccurred())
+			Expect(client.IgnoreNotFound(err)).To(Succeed())
+
+			srcSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sourceSecretName,
+					Namespace: "default",
+				},
+				StringData: map[string]string{
+					"uri_dsn.txt": testDSN,
+				},
+				Type: "Opaque",
+			}
+			Expect(k8sClient.Create(ctxLogger, srcSecret)).To(Succeed())
+
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			By("Cleanup the specific resource instance DatabaseClaim")
+			resource := &persistancev1.DatabaseClaim{}
+			err := k8sClient.Get(ctxLogger, typeNamespacedName, resource)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(k8sClient.Delete(ctxLogger, resource)).To(Succeed())
+			// Reconcile again to finalize the finalizer
+			_, err = controllerReconciler.Reconcile(ctxLogger, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Ensure the resource is deleted")
+			err = k8sClient.Get(ctxLogger, typeNamespacedName, resource)
+			Expect(err).To(HaveOccurred())
+			Expect(client.IgnoreNotFound(err)).To(Succeed())
+
+			By("Cleanup source master creds")
+			srcSecret := &corev1.Secret{}
+			err = k8sClient.Get(ctxLogger, typeNamespacedSourceSecretName, srcSecret)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Delete(ctxLogger, srcSecret)).To(Succeed())
+
+		})
+
+		It("Should succeed with UseExistingSource", func() {
+			By("Reconciling the created resource")
+
+			_, err := controllerReconciler.Reconcile(ctxLogger, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(claim.Status.Error).To(Equal(""))
+			By("Ensuring the active db connection info is set")
+			Eventually(func() *persistancev1.DatabaseClaimConnectionInfo {
+				Expect(k8sClient.Get(ctxLogger, typeNamespacedName, claim)).NotTo(HaveOccurred())
+				return claim.Status.ActiveDB.ConnectionInfo
+			}).ShouldNot(BeNil())
+
+			By("Ensuring NewDb is reset to nil")
+			Expect(claim.Status.NewDB.ConnectionInfo).To(BeNil())
+
+			By("Ensuring the status activedb connection info is set correctly")
+			u, err := url.Parse(testDSN)
+			Expect(err).NotTo(HaveOccurred())
+			aConn := claim.Status.ActiveDB.ConnectionInfo
+			Expect(aConn.Host).To(Equal(u.Hostname()))
+			Expect(aConn.Port).To(Equal(u.Port()))
+			Expect(aConn.Username).To(Equal(u.User.Username() + "_a"))
+			Expect(aConn.DatabaseName).To(Equal(strings.TrimPrefix(u.Path, "/")))
+			Expect(aConn.SSLMode).To(Equal(u.Query().Get("sslmode")))
+
+			By("Checking the DSN in the secret")
+			redacted := u.Redacted()
+			var creds corev1.Secret
+			Expect(k8sClient.Get(ctxLogger, typeNamespacedClaimSecretName, &creds)).NotTo(HaveOccurred())
+			Expect(creds.Data[persistancev1.DSNURIKey]).ToNot(BeNil())
+			dsn, err := url.Parse(string(creds.Data[persistancev1.DSNURIKey]))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.Replace(dsn.Redacted(), "_a", "", 1)).To(Equal(redacted))
+		})
+
+		It("Migrate", func() {
+
+			Expect(controllerReconciler.Reconcile(ctxLogger, reconcile.Request{NamespacedName: typeNamespacedName})).To(Equal(success))
+			var dbc persistancev1.DatabaseClaim
+			Expect(k8sClient.Get(ctxLogger, typeNamespacedName, &dbc)).NotTo(HaveOccurred())
+			Expect(claim.Status.Error).To(Equal(""))
+			By("Ensuring the active db connection info is set")
+			Eventually(func() *persistancev1.DatabaseClaimConnectionInfo {
+				Expect(k8sClient.Get(ctxLogger, typeNamespacedName, &dbc)).NotTo(HaveOccurred())
+				return claim.Status.ActiveDB.ConnectionInfo
+			}).ShouldNot(BeNil())
+
+			hostParams, err := hostparams.New(controllerReconciler.Config.Viper, &dbc)
+			Expect(err).ToNot(HaveOccurred())
+
+			fakeCPSecretName := fmt.Sprintf("%s-%s-%s", env, resourceName, hostParams.Hash())
+
+			By(fmt.Sprintf("Mocking a RDS pod to look like crossplane set it up: %s", fakeCPSecretName))
+			fakeDSN, fakeCancel := dockerdb.MockRDS(GinkgoT(), ctxLogger, k8sClient, fakeCPSecretName, "migrate", dbc.Spec.DatabaseName)
+			_ = fakeCancel
+			// DeferCleanup(fakeCancel)
+
+			fakeCPSecret := corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fakeCPSecretName,
+					Namespace: "default",
+				},
+			}
+			nname := types.NamespacedName{
+				Name:      fakeCPSecretName,
+				Namespace: "default",
+			}
+			Eventually(k8sClient.Get(ctxLogger, nname, &fakeCPSecret)).Should(Succeed())
+			logger.Info("debugsecret", "rdssecret", fakeCPSecret)
+
+			By("Disabling UseExistingSource")
+			Expect(k8sClient.Get(ctxLogger, typeNamespacedName, &dbc)).NotTo(HaveOccurred())
+			dbc.Spec.UseExistingSource = ptr.To(false)
+			Expect(k8sClient.Update(ctxLogger, &dbc)).NotTo(HaveOccurred())
+			res, err := controllerReconciler.Reconcile(ctxLogger, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).To(BeNil())
+			Expect(dbc.Status.Error).To(Equal(""))
+			Expect(res.Requeue).To(BeTrue())
+			Expect(k8sClient.Get(ctxLogger, typeNamespacedName, &dbc)).NotTo(HaveOccurred())
+			By("Check source DSN looks roughly correct")
+			activeDB := dbc.Status.ActiveDB
+			Expect(activeDB.ConnectionInfo).NotTo(BeNil())
+			compareDSN := strings.Replace(testDSN, "//postgres:postgres", "//postgres_b:", 1)
+			Expect(activeDB.ConnectionInfo.Uri()).To(Equal(compareDSN))
+			By("Check target DSN looks roughly correct")
+			newDB := dbc.Status.NewDB
+			compareDSN = strings.Replace(fakeDSN, "//migrate:postgres", "//postgres_a:", 1)
+			Expect(newDB.ConnectionInfo).NotTo(BeNil())
+			Expect(newDB.ConnectionInfo.Uri()).To(Equal(compareDSN))
+			Expect(dbc.Status.MigrationState).To(Equal(pgctl.S_MigrationInProgress.String()))
+
+			var tempCreds corev1.Secret
+			// temp-migrate-dbclaim-creds
+			Expect(k8sClient.Get(ctxLogger, types.NamespacedName{Name: "temp-" + claimSecretName, Namespace: "default"}, &tempCreds)).NotTo(HaveOccurred())
+			for k, v := range tempCreds.Data {
+				logger.Info("tempcreds", k, string(v))
+			}
+
+			By("CR reconciles but must be requeued to perform migration, reconcile manually for test")
+			res, err = controllerReconciler.Reconcile(ctxLogger, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).To(BeNil())
+			Expect(res.Requeue).To(BeFalse())
+			Expect(k8sClient.Get(ctxLogger, typeNamespacedName, &dbc)).NotTo(HaveOccurred())
+			Expect(dbc.Status.Error).To(Equal(""))
+
+			By("Waiting to disable source, reconcile manually again")
+			res, err = controllerReconciler.Reconcile(ctxLogger, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).To(BeNil())
+			Expect(res.RequeueAfter).To(Equal(time.Duration(60)))
+			By("Verify migration is complete on this reconcile")
+			res, err = controllerReconciler.Reconcile(ctxLogger, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).To(BeNil())
+			Expect(res.Requeue).To(BeFalse())
+			Expect(k8sClient.Get(ctxLogger, typeNamespacedName, &dbc)).NotTo(HaveOccurred())
+			Expect(dbc.Status.Error).To(Equal(""))
+			Expect(dbc.Status.MigrationState).To(Equal(pgctl.S_Completed.String()))
+			activeDB = dbc.Status.ActiveDB
+			Expect(activeDB.ConnectionInfo).NotTo(BeNil())
+			Expect(activeDB.ConnectionInfo.Uri()).To(Equal(compareDSN))
+		})
+
+	})
+})

--- a/internal/controller/testdata/mutatingwebhook.yaml
+++ b/internal/controller/testdata/mutatingwebhook.yaml
@@ -1,0 +1,73 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook
+webhooks:
+- clientConfig:
+    service:
+      name: dbproxy
+      path: /mutate--v1-pod
+      namespace: default
+  sideEffects: None
+  admissionReviewVersions: ["v1beta1"]
+  failurePolicy: Fail
+  name: dbproxy.persistance.atlas.infoblox.com
+  objectSelector:
+    matchExpressions:
+      # This will locate a databaseclaim or a dbroleclaim
+      - key: "persistance.atlas.infoblox.com/claim"
+        operator: "Exists"
+      - key: "persistance.atlas.infoblox.com/dbproxy"
+        operator: "In"
+        values:
+          - "enabled"
+        # Important to prevent multiple db-controllers from stepping on each other
+      - key: "persistance.atlas.infoblox.com/class"
+        operator: "In"
+        values:
+          - "testenv"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+    scope: "Namespaced"
+- clientConfig:
+    service:
+      name: dbproxy
+      path: /mutate--v1-pod
+      namespace: default
+  sideEffects: None
+  admissionReviewVersions: ["v1beta1"]
+  failurePolicy: Fail
+  name: dsnexec.persistance.atlas.infoblox.com
+  objectSelector:
+    matchExpressions:
+      # This will locate a databaseclaim or a dbroleclaim
+      - key: "persistance.atlas.infoblox.com/claim"
+        operator: "Exists"
+      - key: "persistance.atlas.infoblox.com/dsnexec"
+        operator: "In"
+        values:
+          - "enabled"
+        # Important to prevent multiple db-controllers from stepping on each other
+      - key: "persistance.atlas.infoblox.com/class"
+        operator: "In"
+        values:
+          - "testenv"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+    scope: "Namespaced"

--- a/internal/dockerdb/mockdb.go
+++ b/internal/dockerdb/mockdb.go
@@ -1,0 +1,55 @@
+package dockerdb
+
+import (
+	"context"
+	"net/url"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func MockRDS(t GinkgoTInterface, ctx context.Context, cli client.Client, secretName, userName, databaseName string) (string, func()) {
+	t.Helper()
+
+	_, fakeDSN, clean := Run(Config{
+		Database:  databaseName,
+		Username:  userName,
+		Password:  "postgres",
+		DockerTag: "15",
+	})
+
+	fakeDSN = strings.Replace(fakeDSN, "localhost", "127.0.0.1", 1)
+
+	u, err := url.Parse(fakeDSN)
+	if err != nil {
+		t.Fatalf("failed to parse fakeDSN: %v", err)
+	}
+	pw, _ := u.User.Password()
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"endpoint": []byte(u.Hostname()),
+			"password": []byte(pw),
+			"port":     []byte(u.Port()),
+			"username": []byte(u.User.Username()),
+		},
+	}
+	if err := cli.Create(ctx, secret); err != nil {
+		t.Fatalf("failed to create secret: %v", err)
+	}
+
+	return fakeDSN, func() {
+		if err := cli.Delete(ctx, secret); err != nil {
+			t.Fatalf("failed to delete secret: %v", err)
+		}
+		clean()
+	}
+}

--- a/internal/webhook/dbproxy_test.go
+++ b/internal/webhook/dbproxy_test.go
@@ -8,7 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	v1 "github.com/infobloxopen/db-controller/api/v1"
 )
@@ -32,7 +31,6 @@ var _ = Describe("dbproxy defaulting", func() {
 				Namespace: "default",
 			},
 			Spec: v1.DatabaseClaimSpec{
-				Class:      ptr.To("default"),
 				SecretName: "test",
 			},
 		}
@@ -164,6 +162,7 @@ func makePodProxy(name, claimName string) *corev1.Pod {
 		pod.Labels = map[string]string{
 			LabelCheckProxy: "enabled",
 			LabelClaim:      claimName,
+			LabelClass:      "default",
 		}
 	case "annotation-disabled":
 		pod.Labels = map[string]string{}

--- a/internal/webhook/dbproxy_test.go
+++ b/internal/webhook/dbproxy_test.go
@@ -35,6 +35,10 @@ var _ = Describe("dbproxy defaulting", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "default-db"}, resource)
+			return err == nil
+		}).Should(BeTrue())
 
 	})
 

--- a/internal/webhook/dsnexec_test.go
+++ b/internal/webhook/dsnexec_test.go
@@ -35,6 +35,10 @@ var _ = Describe("dsnexec defaulting", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "default-db"}, resource)
+			return err == nil
+		}).Should(BeTrue())
 
 	})
 

--- a/internal/webhook/dsnexec_test.go
+++ b/internal/webhook/dsnexec_test.go
@@ -8,7 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	v1 "github.com/infobloxopen/db-controller/api/v1"
 )
@@ -32,7 +31,6 @@ var _ = Describe("dsnexec defaulting", func() {
 				Namespace: "default",
 			},
 			Spec: v1.DatabaseClaimSpec{
-				Class:      ptr.To("default"),
 				SecretName: "test",
 			},
 		}
@@ -169,6 +167,7 @@ func makePodExec(name, claimName string) *corev1.Pod {
 			LabelCheckExec:  "enabled",
 			LabelClaim:      claimName,
 			LabelConfigExec: "dsnexec-config-secret",
+			LabelClass:      "default",
 		}
 	case "annotation-disabled":
 		pod.Labels = map[string]string{}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -1,0 +1,105 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "github.com/infobloxopen/db-controller/api/v1"
+	"github.com/infobloxopen/db-controller/pkg/kctlutils"
+)
+
+// Creds contains the many authentications available during a
+// request
+type Creds struct {
+	SourceDSN, TargetDSN   string
+	SourceUser, TargetUser string
+}
+
+// FromContext returns the Creds from the context
+func FromContext(ctx context.Context) *Creds {
+	return ctx.Value("creds").(*Creds)
+}
+
+// NewContext returns a new context with the Creds
+func NewContext(ctx context.Context, creds *Creds) context.Context {
+	return context.WithValue(ctx, "creds", creds)
+}
+
+// UpdateDSNWithPassword updates the DSN with the password
+func UpdateDSNWithPassword(dsn, password string) (string, error) {
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return "", err
+	}
+	u.User = url.UserPassword(u.User.Username(), password)
+	return u.String(), nil
+}
+
+// PopulateCreds attempts to find creds from the variety of places
+// they can be found in
+func PopulateCreds(ctx context.Context, cli client.Reader, dbClaim *v1.DatabaseClaim, serviceNS string) (*Creds, error) {
+
+	secret := &corev1.Secret{}
+	err := cli.Get(ctx, client.ObjectKey{
+		Namespace: dbClaim.Namespace,
+		Name:      dbClaim.Spec.SecretName,
+	}, secret)
+	if err != nil {
+		return nil, err
+	}
+
+	srcAdmin, err := fetchAdminFromSourceDataFrom(ctx, cli, dbClaim)
+	if err != nil {
+		srcAdmin, err = fetchAdminFromActiveDB(ctx, cli, dbClaim, serviceNS)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &Creds{
+		SourceDSN: srcAdmin,
+	}, nil
+}
+
+// GetSourceDataFromDSN returns the DSN from the source data from
+// DSN field or secretRef.
+func GetSourceDataFromDSN(ctx context.Context, cli client.Reader, dbClaim *v1.DatabaseClaim) (string, error) {
+	return fetchAdminFromSourceDataFrom(ctx, cli, dbClaim)
+}
+
+// fetchAdminFromSourceDataFrom reads the raw DSN and secretRef
+func fetchAdminFromSourceDataFrom(ctx context.Context, cli client.Reader, dbClaim *v1.DatabaseClaim) (string, error) {
+	var srcAdmin string
+	// Fetch source from sourcedatafrom location
+	if dbClaim.Spec.SourceDataFrom != nil {
+		srcAdmin = dbClaim.Spec.SourceDataFrom.Database.DSN
+		if srcAdmin == "" {
+			info, err := getSourceDataFromDSN(ctx, cli, dbClaim)
+			if err != nil {
+				return "", err
+			}
+			return info.Uri(), nil
+		}
+	}
+	return srcAdmin, nil
+}
+
+func fetchAdminFromActiveDB(ctx context.Context, cli client.Reader, dbClaim *v1.DatabaseClaim, serviceNS string) (string, error) {
+	if dbClaim.Status.ActiveDB.ConnectionInfo != nil && dbClaim.Status.ActiveDB.ConnectionInfo.Uri() != "" {
+
+		activeHost, _, _ := strings.Cut(dbClaim.Status.ActiveDB.ConnectionInfo.Host, ".")
+
+		kctl := kctlutils.New(cli, serviceNS)
+		connInfo, err := kctl.GetMasterCredsDeprecated(ctx, activeHost, dbClaim.Spec.DatabaseName, dbClaim.Status.ActiveDB.ConnectionInfo.SSLMode)
+		if err != nil {
+			return "", err
+		}
+		return connInfo.Uri(), nil
+	}
+	return "", errors.New("unable to fetch source admin")
+}

--- a/pkg/auth/existing_password_test.go
+++ b/pkg/auth/existing_password_test.go
@@ -1,6 +1,7 @@
-package databaseclaim
+package auth
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -9,6 +10,8 @@ import (
 )
 
 func TestExistingDSN(t *testing.T) {
+
+	ctx := context.Background()
 
 	for _, tt := range []struct {
 		name       string
@@ -29,7 +32,8 @@ func TestExistingDSN(t *testing.T) {
 			user: "postgres",
 			name: "no dsn w/no secret password",
 			secretData: map[string][]byte{
-				"dsn.txt": []byte("postgres://postgres:dsnPassword@localhost:5432/postgres?sslmode=disable"),
+				"dsn.txt":     []byte("host=localhost port=5432 user=postgres password=dsnPassword dbname=postgres sslmode=disable"),
+				"uri_dsn.txt": []byte("postgres://postgres:dsnPassword@localhost:5432/postgres?sslmode=disable"),
 			},
 			dsn:      "postgres://postgres@localhost:5432/postgres?sslmode=disable",
 			expected: "postgres://postgres:dsnPassword@localhost:5432/postgres?sslmode=disable",
@@ -57,7 +61,7 @@ func TestExistingDSN(t *testing.T) {
 					},
 				},
 			}
-			actual, err := parseExistingDSN(tt.secretData, claim)
+			actual, err := parseExistingDSN(ctx, tt.secretData, claim)
 			if !errors.Is(err, tt.error) {
 				t.Errorf("got: %v, wanted: %v", err, tt.error)
 			}

--- a/pkg/auth/sources.go
+++ b/pkg/auth/sources.go
@@ -14,7 +14,7 @@ import (
 
 var ErrInvalidCredentialsPasswordMissing = fmt.Errorf("invalid_credentials_password_missing")
 
-func getSourceDataFromDSN(ctx context.Context, cli client.Reader, dbClaim *v1.DatabaseClaim) (*v1.DatabaseClaimConnectionInfo, error) {
+func getSourceDataFromSecretRef(ctx context.Context, cli client.Reader, dbClaim *v1.DatabaseClaim) (*v1.DatabaseClaimConnectionInfo, error) {
 
 	ns := dbClaim.Spec.SourceDataFrom.Database.SecretRef.Namespace
 	if ns == "" {

--- a/pkg/auth/sources.go
+++ b/pkg/auth/sources.go
@@ -1,4 +1,4 @@
-package databaseclaim
+package auth
 
 import (
 	"context"
@@ -7,34 +7,40 @@ import (
 	_ "github.com/lib/pq"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1 "github.com/infobloxopen/db-controller/api/v1"
 )
 
 var ErrInvalidCredentialsPasswordMissing = fmt.Errorf("invalid_credentials_password_missing")
 
-func getExistingDSN(ctx context.Context, cli client.Reader, dbClaim *v1.DatabaseClaim) (*v1.DatabaseClaimConnectionInfo, error) {
+func getSourceDataFromDSN(ctx context.Context, cli client.Reader, dbClaim *v1.DatabaseClaim) (*v1.DatabaseClaimConnectionInfo, error) {
 
 	ns := dbClaim.Spec.SourceDataFrom.Database.SecretRef.Namespace
 	if ns == "" {
 		ns = dbClaim.Namespace
 	}
-
-	secret := corev1.Secret{}
-	err := cli.Get(ctx, client.ObjectKey{
+	key := client.ObjectKey{
 		Namespace: ns,
 		Name:      dbClaim.Spec.SourceDataFrom.Database.SecretRef.Name,
-	}, &secret)
+	}
+
+	secret := corev1.Secret{}
+	err := cli.Get(ctx, key, &secret)
 	if err != nil {
 		return nil, err
 	}
 
-	return parseExistingDSN(secret.Data, dbClaim)
+	return parseExistingDSN(ctx, secret.Data, dbClaim)
 }
 
-func parseExistingDSN(secretData map[string][]byte, dbClaim *v1.DatabaseClaim) (*v1.DatabaseClaimConnectionInfo, error) {
+func parseExistingDSN(ctx context.Context, secretData map[string][]byte, dbClaim *v1.DatabaseClaim) (*v1.DatabaseClaimConnectionInfo, error) {
 
-	bsDSN, ok := secretData[v1.DSNKey]
+	logr := log.FromContext(ctx)
+	for k, v := range secretData {
+		logr.Info("parseExistingDSN", "key", k, "value", string(v))
+	}
+	bsDSN, ok := secretData[v1.DSNURIKey]
 	if ok {
 		uriDSN, err := v1.ParseUri(string(bsDSN))
 		if err == nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/viper"
@@ -13,12 +14,14 @@ var configLog = ctrl.Log.WithName("configLog")
 // NewConfig creates a new db-controller config
 func NewConfig(configFile string) *viper.Viper {
 	c := viper.NewWithOptions(viper.KeyDelimiter("::"))
+	c.AutomaticEnv()
 	c.SetDefault("config", "config.yaml")
 	c.SetConfigFile(configFile)
 	configLog.Info("loading config")
 	err := c.ReadInConfig() // Find and read the config file
 	if err != nil {         // Handle errors reading the config file
-		panic(fmt.Errorf("fatal error config file: %s", err))
+		configLog.Error(err, "error reading config file", "file", configFile)
+		os.Exit(1)
 	}
 
 	// monitor the changes in the config file

--- a/pkg/databaseclaim/awsprovider.go
+++ b/pkg/databaseclaim/awsprovider.go
@@ -191,7 +191,7 @@ func (r *DatabaseClaimReconciler) manageDBClusterAWS(ctx context.Context, dbHost
 		return false, err
 	}
 
-	return r.isResourceReady(dbCluster.Status.ResourceStatus)
+	return r.isResourceReady("aurora.cluster", dbHostName, dbCluster.Status.ResourceStatus)
 }
 
 func (r *DatabaseClaimReconciler) managePostgresDBInstanceAWS(ctx context.Context, reqInfo *requestInfo, dbHostName string, dbClaim *v1.DatabaseClaim, operationalMode ModeEnum) (bool, error) {
@@ -333,7 +333,7 @@ func (r *DatabaseClaimReconciler) managePostgresDBInstanceAWS(ctx context.Contex
 	if err != nil {
 		return false, err
 	}
-	return r.isResourceReady(dbInstance.Status.ResourceStatus)
+	return r.isResourceReady("rds.instance", dbHostName, dbInstance.Status.ResourceStatus)
 }
 
 func (r *DatabaseClaimReconciler) updateDBClusterAWS(ctx context.Context, reqInfo *requestInfo, dbClaim *v1.DatabaseClaim, dbCluster *crossplaneaws.DBCluster) (bool, error) {
@@ -458,7 +458,7 @@ func (r *DatabaseClaimReconciler) manageAuroraDBInstance(ctx context.Context, re
 		return false, err
 	}
 
-	return r.isResourceReady(dbInstance.Status.ResourceStatus)
+	return r.isResourceReady("aurora.instance", dbHostName, dbInstance.Status.ResourceStatus)
 }
 
 func (r *DatabaseClaimReconciler) managePostgresParamGroup(ctx context.Context, reqInfo *requestInfo, dbClaim *v1.DatabaseClaim) (string, error) {

--- a/pkg/databaseclaim/creds.go
+++ b/pkg/databaseclaim/creds.go
@@ -1,0 +1,77 @@
+package databaseclaim
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/infobloxopen/db-controller/pkg/dbclient"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func validateAndUpdateCredsDSN(ctx context.Context, adminDSN, userDSN string) error {
+	logger := log.FromContext(ctx).WithValues("caller", "validateAndUpdateCredsDSN")
+	dbClient, err := dbclient.New(dbclient.Config{
+		Log:    logger,
+		DBType: "postgres",
+		DSN:    adminDSN,
+	})
+	if err != nil {
+		logger.Error(err, "unable_create_dbclient")
+		return err
+	}
+
+	return validateAndUpdateCreds(ctx, dbClient, userDSN)
+}
+
+func validateAndUpdateCreds(ctx context.Context, cli dbclient.Clienter, currentConnDSN string) error {
+	logger := log.FromContext(ctx).WithValues("admin", cli.SanitizeDSN())
+	// If we're given an empty DSN, ignore it
+	if currentConnDSN == "" {
+		return nil
+	}
+
+	if err := cli.Ping(); err != nil {
+		logger.Error(err, "admin_unable_connect")
+		return fmt.Errorf("unable_connect: %w", err)
+	}
+
+	logger.V(1).Info("verifying_existing_creds", "conn_dsn", currentConnDSN)
+	curCli, err := dbclient.New(dbclient.Config{
+		Log:    logger,
+		DBType: "postgres",
+		DSN:    currentConnDSN,
+	})
+	if err != nil {
+		return fmt.Errorf("unable_create_dbclient: %w", err)
+	}
+	logger = logger.WithValues("user", currentConnDSN)
+
+	err = curCli.DB.Ping()
+	if err == nil {
+		return nil
+	}
+
+	logger.Info("unable_connect_updating_user", "err", err)
+
+	parsedDSN, err := url.Parse(currentConnDSN)
+	if err != nil {
+		return err
+	}
+	pw, ok := parsedDSN.User.Password()
+	if !ok || len(pw) == 0 {
+		return fmt.Errorf("password unavailable to update")
+	}
+	if err := cli.UpdatePassword(parsedDSN.User.Username(), pw); err != nil {
+		return err
+	}
+
+	err = curCli.DB.Ping()
+	if err == nil {
+		logger.Info("user_able_connect_after_update!!")
+		return nil
+	}
+	logger.Error(err, "user_unable_connect_after_update", "dsn", currentConnDSN)
+
+	return fmt.Errorf("failed_to_ping_after_update: %w", err)
+}

--- a/pkg/databaseclaim/gcpprovider.go
+++ b/pkg/databaseclaim/gcpprovider.go
@@ -264,7 +264,7 @@ func (r *DatabaseClaimReconciler) manageDBClusterGCP(ctx context.Context, reqInf
 		return false, err
 	}
 
-	return r.isResourceReady(dbCluster.Status.ResourceStatus)
+	return r.isResourceReady("alloydb.cluster", dbHostName, dbCluster.Status.ResourceStatus)
 }
 
 // https://cloud.google.com/alloydb/docs/reference/rest/v1beta/DatabaseVersion
@@ -354,7 +354,7 @@ func (r *DatabaseClaimReconciler) managePostgresDBInstanceGCP(ctx context.Contex
 				return false, err
 			}
 			//create DBInstance
-			logr.Info("creating crossplane DBInstance resource", "DBInstance", dbInstance.Name)
+			logr.Info("creating crossplane alloydb.instance", "instance", dbInstance.Name)
 			if err := r.Client.Create(ctx, dbInstance); err != nil {
 				return false, err
 			}
@@ -369,7 +369,7 @@ func (r *DatabaseClaimReconciler) managePostgresDBInstanceGCP(ctx context.Contex
 		return false, err
 	}
 
-	return r.isResourceReady(dbInstance.Status.ResourceStatus)
+	return r.isResourceReady("alloydb.instance", dbHostName, dbInstance.Status.ResourceStatus)
 }
 
 func (r *DatabaseClaimReconciler) updateDBClusterGCP(ctx context.Context, reqInfo *requestInfo, dbClaim *v1.DatabaseClaim, dbCluster *crossplanegcp.Cluster) (bool, error) {

--- a/pkg/databaseclaim/modeenum.go
+++ b/pkg/databaseclaim/modeenum.go
@@ -1,0 +1,139 @@
+package databaseclaim
+
+import (
+	"context"
+	"fmt"
+
+	v1 "github.com/infobloxopen/db-controller/api/v1"
+	"github.com/infobloxopen/db-controller/pkg/hostparams"
+	"github.com/infobloxopen/db-controller/pkg/pgctl"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type ModeEnum int
+
+const (
+	M_NotSupported ModeEnum = iota
+	M_UseExistingDB
+	M_MigrateExistingToNewDB
+	M_MigrationInProgress
+	M_UseNewDB
+	M_InitiateDBUpgrade
+	M_UpgradeDBInProgress
+	M_PostMigrationInProgress
+)
+
+// getMode determines the mode of operation for the database claim.
+func (r *DatabaseClaimReconciler) getMode(ctx context.Context, reqInfo *requestInfo, dbClaim *v1.DatabaseClaim) ModeEnum {
+	return getMode(ctx, reqInfo, dbClaim)
+}
+
+func getMode(ctx context.Context, reqInfo *requestInfo, dbClaim *v1.DatabaseClaim) ModeEnum {
+	// Shadow variable
+	log := log.FromContext(ctx).WithValues("databaseclaim", dbClaim.Namespace+"/"+dbClaim.Name, "func", "getMode")
+	//default mode is M_UseNewDB. any non supported combination needs to be identified and set to M_NotSupported
+
+	if dbClaim.Status.OldDB.DbState == v1.PostMigrationInProgress {
+		if dbClaim.Status.OldDB.ConnectionInfo == nil || dbClaim.Status.ActiveDB.DbState != v1.Ready ||
+			reqInfo.SharedDBHost {
+			return M_NotSupported
+		}
+	}
+
+	if dbClaim.Status.OldDB.DbState == v1.PostMigrationInProgress && dbClaim.Status.ActiveDB.DbState == v1.Ready {
+		return M_PostMigrationInProgress
+	}
+
+	if reqInfo.SharedDBHost {
+		if dbClaim.Status.ActiveDB.DbState == v1.UsingSharedHost {
+			activeHostParams := hostparams.GetActiveHostParams(dbClaim)
+			if reqInfo.HostParams.IsUpgradeRequested(activeHostParams) {
+				log.Info("upgrade requested for a shared host. shared host upgrades are not supported. ignoring upgrade request")
+			}
+		}
+		log.V(debugLevel).Info("selected mode for shared db host", "dbclaim", dbClaim.Spec, "selected mode", "M_UseNewDB")
+
+		return M_UseNewDB
+	}
+
+	// use existing is true
+	if dbClaim.Spec.UseExistingSource != nil && *dbClaim.Spec.UseExistingSource {
+		if dbClaim.Spec.SourceDataFrom == nil {
+			log.Error(fmt.Errorf("source data from is nil"), "unsupported mode")
+			return M_NotSupported
+		}
+		if dbClaim.Spec.SourceDataFrom.Type != "database" {
+			log.Error(fmt.Errorf("unsupported SourceDataFrom.Type %s must be one of %q", dbClaim.Spec.SourceDataFrom.Type, []string{"database"}), "unsupported mode")
+			return M_NotSupported
+		}
+
+		log.V(debugLevel).Info("selected mode for", "selected mode", "M_UseExistingDB")
+		return M_UseExistingDB
+	}
+
+	// use existing is false // source data is present
+	if dbClaim.Spec.SourceDataFrom != nil {
+		if dbClaim.Spec.SourceDataFrom.Type != "database" {
+			log.Error(fmt.Errorf("unsupported sourcedata from type"), "source data from type not supported")
+			return M_NotSupported
+		}
+
+		if dbClaim.Status.ActiveDB.DbState == v1.UsingExistingDB {
+			switch dbClaim.Status.MigrationState {
+			case pgctl.S_Initial.String():
+				fallthrough
+			case "":
+				log.V(debugLevel).Info("selected mode for", "dbclaim", dbClaim.Spec, "selected mode", "M_MigrateExistingToNewDB")
+				return M_MigrateExistingToNewDB
+			case pgctl.S_Completed.String():
+				// Does nothing, behavior is undefined in existing logic
+			default:
+				log.V(debugLevel).Info("selected mode for", "dbclaim", dbClaim.Spec, "selected mode", "M_MigrationInProgress")
+				return M_MigrationInProgress
+			}
+		}
+	}
+	// use existing is false // source data is not present
+	if dbClaim.Spec.SourceDataFrom == nil {
+		if dbClaim.Status.ActiveDB.DbState == v1.UsingExistingDB {
+			//make sure status contains all the requires sourceDataFrom info
+			if dbClaim.Status.ActiveDB.SourceDataFrom != nil {
+				dbClaim.Spec.SourceDataFrom = dbClaim.Status.ActiveDB.SourceDataFrom.DeepCopy()
+				if dbClaim.Status.MigrationState == "" || dbClaim.Status.MigrationState == pgctl.S_Initial.String() {
+					log.V(debugLevel).Info("selected mode for", "dbclaim", dbClaim.Spec, "selected mode", "M_MigrateExistingToNewDB")
+					return M_MigrateExistingToNewDB
+				} else if dbClaim.Status.MigrationState != pgctl.S_Completed.String() {
+					log.V(debugLevel).Info("selected mode for", "dbclaim", dbClaim.Spec, "selected mode", "M_MigrationInProgress")
+					return M_MigrationInProgress
+				}
+			} else {
+				log.Info("something is wrong. use existing is false // source data is not present. sourceDataFrom is not present in status")
+				return M_NotSupported
+			}
+		}
+	}
+
+	// use existing is false; source data is not present ; active status is using-existing-db or ready
+	// activeDB does not have sourceDataFrom info
+	if dbClaim.Status.ActiveDB.DbState == v1.Ready {
+		activeHostParams := hostparams.GetActiveHostParams(dbClaim)
+		if reqInfo.HostParams.IsUpgradeRequested(activeHostParams) {
+			if dbClaim.Status.NewDB.DbState == "" {
+				dbClaim.Status.NewDB.DbState = v1.InProgress
+				dbClaim.Status.MigrationState = ""
+			}
+			if dbClaim.Status.MigrationState == "" || dbClaim.Status.MigrationState == pgctl.S_Initial.String() {
+				log.V(debugLevel).Info("selected mode for", "dbclaim", dbClaim.Spec, "selected mode", "M_InitiateDBUpgrade")
+				return M_InitiateDBUpgrade
+			} else if dbClaim.Status.MigrationState != pgctl.S_Completed.String() {
+				log.V(debugLevel).Info("selected mode for", "dbclaim", dbClaim.Spec, "selected mode", "M_UpgradeDBInProgress")
+				return M_UpgradeDBInProgress
+
+			}
+		}
+	}
+
+	log.V(debugLevel).Info("selected mode for", "dbclaim", dbClaim.Spec, "selected mode", "M_UseNewDB")
+
+	return M_UseNewDB
+}

--- a/pkg/dbclient/interface.go
+++ b/pkg/dbclient/interface.go
@@ -1,6 +1,10 @@
 package dbclient
 
-import "github.com/aws/aws-sdk-go-v2/aws"
+import (
+	"database/sql"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
 
 type Clienter interface {
 	Creater
@@ -8,6 +12,10 @@ type Clienter interface {
 	Remover
 	Exister
 	DBCloser
+
+	GetDB() *sql.DB
+	Ping() error
+	SanitizeDSN() string
 
 	ManageReplicationRole(username string, enableReplicationRole bool) error
 	ManageSuperUserRole(username string, enableSuperUser bool) error

--- a/pkg/kctlutils/kctl.go
+++ b/pkg/kctlutils/kctl.go
@@ -1,0 +1,122 @@
+package kctlutils
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	v1 "github.com/infobloxopen/db-controller/api/v1"
+)
+
+type Client struct {
+	cli       client.Reader
+	serviceNS string
+	// cfg       *viper.Viper
+}
+
+func New(c client.Reader, serviceNS string) *Client {
+	return &Client{
+		cli:       c,
+		serviceNS: serviceNS,
+	}
+}
+
+// MasterCreds reads the master credentials that crossplane
+// has stored in the secret
+// Returns a DSN
+func (c *Client) GetMasterDSN(ctx context.Context, secretName, databaseName, sslMode string) (string, error) {
+	info, err := c.GetMasterCredsDeprecated(ctx, secretName, databaseName, sslMode)
+	if err != nil {
+		return "", err
+	}
+	return info.Uri(), nil
+}
+
+// GetMasterCredsDeprecated reads the master credentials
+// FIXME: switch to the new GetMasterDSN
+func (c *Client) GetMasterCredsDeprecated(ctx context.Context, secretName, databaseName string, sslMode string) (v1.DatabaseClaimConnectionInfo, error) {
+
+	connInfo := v1.DatabaseClaimConnectionInfo{}
+	if databaseName == "" {
+		return connInfo, fmt.Errorf("database name is required")
+	}
+	if c.serviceNS == "" {
+		return connInfo, fmt.Errorf("service namespace is required")
+	}
+
+	rs := &corev1.Secret{}
+	serviceNS := c.serviceNS
+
+	err := c.cli.Get(ctx, client.ObjectKey{
+		Namespace: serviceNS,
+		Name:      secretName,
+	}, rs)
+	//TODO handle not found vs other errors here
+	if err != nil {
+		return connInfo, err
+	}
+
+	connInfo.DatabaseName = databaseName
+	connInfo.Host = string(rs.Data["endpoint"])
+	connInfo.Port = string(rs.Data["port"])
+	connInfo.Username = string(rs.Data["username"])
+	connInfo.Password = string(rs.Data["password"])
+	connInfo.SSLMode = sslMode
+
+	log.FromContext(ctx).Info("GetMasterCredsDeprecated", "secret", secretName, "info", connInfo)
+
+	if connInfo.Host == "" ||
+		connInfo.Port == "" ||
+		connInfo.Username == "" ||
+		connInfo.Password == "" {
+		return connInfo, fmt.Errorf("generated secret is incomplete")
+	}
+
+	return connInfo, nil
+}
+
+// GetConnDSN reads the connection secret created by db-controller
+func (c *Client) GetConnDSN(ctx context.Context, dbClaim *v1.DatabaseClaim) (string, error) {
+	connInfo, err := c.GetConnSecret(ctx, dbClaim)
+	if err != nil {
+		return "", err
+	}
+	return connInfo.Uri(), nil
+}
+
+// GetConnSecret reads the connection secret created by db-controller
+func (c *Client) GetConnSecret(ctx context.Context, dbClaim *v1.DatabaseClaim) (*v1.DatabaseClaimConnectionInfo, error) {
+
+	connInfo := v1.DatabaseClaimConnectionInfo{}
+
+	rs := corev1.Secret{}
+
+	err := c.cli.Get(ctx, client.ObjectKey{
+		Namespace: dbClaim.Namespace,
+		Name:      dbClaim.Spec.SecretName,
+	}, &rs)
+	//TODO handle not found vs other errors here
+	if err != nil {
+		return &connInfo, err
+	}
+
+	connInfo.Host = string(rs.Data["hostname"])
+	connInfo.Port = string(rs.Data["port"])
+	connInfo.Username = string(rs.Data["username"])
+	connInfo.Password = string(rs.Data["password"])
+	connInfo.SSLMode = string(rs.Data["sslmode"])
+	connInfo.DatabaseName = string(rs.Data["database"])
+
+	if connInfo.DatabaseName == "" ||
+		connInfo.Host == "" ||
+		connInfo.Port == "" ||
+		connInfo.Username == "" ||
+		connInfo.Password == "" {
+		return &connInfo, fmt.Errorf("generated secret is incomplete")
+	}
+
+	return &connInfo, nil
+}

--- a/pkg/pgctl/stateEnum.go
+++ b/pkg/pgctl/stateEnum.go
@@ -16,6 +16,7 @@ const (
 	S_RerouteTargetSecret
 	S_WaitToDisableSource
 	S_DisableSourceAccess
+	S_MigrationInProgress
 	S_ValidateMigrationStatus
 	S_DisableSubscription
 	S_DeleteSubscription
@@ -50,6 +51,8 @@ func (s StateEnum) String() string {
 		return "wait_to_disable_source"
 	case S_DisableSourceAccess:
 		return "disable_source_access"
+	case S_MigrationInProgress:
+		return "migration_in_progress"
 	case S_ValidateMigrationStatus:
 		return "validate_migration_status"
 	case S_DisableSubscription:
@@ -80,6 +83,7 @@ func init() {
 	stateMap[S_ResetTargetSequence.String()] = S_ResetTargetSequence
 	stateMap[S_RerouteTargetSecret.String()] = S_RerouteTargetSecret
 	stateMap[S_DisableSourceAccess.String()] = S_DisableSourceAccess
+	stateMap[S_MigrationInProgress.String()] = S_MigrationInProgress
 	stateMap[S_ValidateMigrationStatus.String()] = S_ValidateMigrationStatus
 	stateMap[S_WaitToDisableSource.String()] = S_WaitToDisableSource
 	stateMap[S_DisableSubscription.String()] = S_DisableSubscription

--- a/pkg/pgctl/test/pgctl_source_test_data.sql
+++ b/pkg/pgctl/test/pgctl_source_test_data.sql
@@ -44,7 +44,9 @@ set     rds.logical_replication static parameter to 1
 -- CREATE DATABASE pub;
 -- \c pub
 -- simulate AWS rds_superuser role
-CREATE ROLE rds_superuser WITH INHERIT LOGIN;
+-- testdb injects these now    
+-- CREATE ROLE rds_superuser WITH INHERIT LOGIN;
+-- CREATE ROLE alloydbsuperuser WITH INHERIT LOGIN;
 
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 

--- a/pkg/pgctl/test/pgctl_target_test_data.sql
+++ b/pkg/pgctl/test/pgctl_target_test_data.sql
@@ -3,7 +3,9 @@
 -- CREATE DATABASE pub;
 -- \c pub
 -- simulate AWS rds_superuser role
-CREATE ROLE rds_superuser WITH INHERIT LOGIN;
+-- testdb injects these now
+-- CREATE ROLE rds_superuser WITH INHERIT LOGIN;
+-- CREATE ROLE alloydbsuperuser WITH INHERIT LOGIN;
 
 DO $$
 BEGIN

--- a/test/e2e/dbc_end2end_test.go
+++ b/test/e2e/dbc_end2end_test.go
@@ -82,7 +82,7 @@ var _ = Describe("dbc-end2end", Ordered, func() {
 
 			Expect(db1).NotTo(BeEmpty())
 			key := types.NamespacedName{
-				Name:      env + "-" + db1,
+				Name:      db1,
 				Namespace: namespace,
 			}
 
@@ -123,7 +123,7 @@ var _ = Describe("dbc-end2end", Ordered, func() {
 				dbinstance1 = fmt.Sprintf("%s-%s-%s", env, db1, hostParams.Hash())
 			}
 
-			By("Checking if dbinstance exists")
+			By(fmt.Sprintf("Checking if dbinstance exists: %s", dbinstance1))
 			Expect(dbinstance1).NotTo(BeEmpty())
 			dbInst := utils.DBInstanceType(cloud)
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: dbinstance1}, dbInst)
@@ -137,7 +137,7 @@ var _ = Describe("dbc-end2end", Ordered, func() {
 
 			Expect(k8sClient.Create(ctx, dbClaim)).Should(Succeed())
 
-			By(fmt.Sprintf("checking %s status.error message is not empty", key.String()))
+			By(fmt.Sprintf("dbc status.error messages it not empty: %s", key.String()))
 			Eventually(func() string {
 				Expect(k8sClient.Get(ctx, key, dbClaim)).Should(Succeed())
 				return dbClaim.Status.Error
@@ -148,7 +148,7 @@ var _ = Describe("dbc-end2end", Ordered, func() {
 		It("Updating a databaseclaim", func() {
 			By("setting DBVersion to empty should use value 15")
 			key := types.NamespacedName{
-				Name:      env + "-" + db1,
+				Name:      db1,
 				Namespace: namespace,
 			}
 
@@ -284,7 +284,7 @@ var _ = Describe("dbc-end2end", Ordered, func() {
 					SecretName: secretName,
 					SourceDatabaseClaim: &v1.SourceDatabaseClaim{
 						Namespace: namespace,
-						Name:      env + "-" + db1,
+						Name:      db1,
 					},
 					SchemaRoleMap: map[string]v1.RoleType{
 						"schemaapp111": v1.ReadOnly,
@@ -622,36 +622,10 @@ var _ = Describe("dbc-end2end", Ordered, func() {
 		})
 	})
 
-	// FIXME: only clean up resources that this test suite created
+	// FIXME: afterall is not executed, move these to AfterSuite
 	var afterall = func() {
 		if os.Getenv("NOCLEANUP") != "" {
 			return
-		}
-		By("Cleaning up resources")
-
-		// delete db1 if it exists
-		claim := &v1.DatabaseClaim{}
-		for _, db := range []string{db1, db2} {
-			nname := types.NamespacedName{
-				Name:      db,
-				Namespace: namespace,
-			}
-			if err := k8sClient.Get(ctx, nname, claim); err == nil {
-				By("Deleting DatabaseClaim: " + db)
-				Expect(k8sClient.Delete(ctx, claim)).Should(Succeed())
-			}
-		}
-
-		inst := &crossplaneaws.DBInstance{}
-		for _, db := range []string{dbinstance1, dbinstance1update, dbinstance2} {
-			nname := types.NamespacedName{
-				Name:      db,
-				Namespace: namespace,
-			}
-			if err := k8sClient.Get(ctx, nname, inst); err == nil {
-				By("Deleting DBInstance: " + db)
-				Expect(k8sClient.Delete(ctx, inst)).Should(Succeed())
-			}
 		}
 
 		return


### PR DESCRIPTION
    The state machine was not being used effectively to go from the
    new cloud db step to the migration step. The controller now
    reconciles fully after a database is created and requeues. On
    next requeue, controller performs a migration to the new database.

    I attempted to identify issues storing, retrieiving and using db
    credentials. In all places possible, a uri dsn is now used. There
    is still significant cleanup in this regard. The usage of storing
    state in requestinfo needs to be eliminated. RequestInfo makes the
    code perform in a spaghetti fashion where you follow logic only to
    find it calling other states non-recurisvely or putting the dbc in
    a broken state when random errors occur.

    - fix grant/revoke superuser
    - support gcp alloydb roles
    - pass cloud into dbclient pkg calls
    - ignore sql revoke errors on non-cloud dbs
    - separate kubectl client for finding cloud based master credentials
    - push sql updatepassword when credentials are denied
    - always set status when existing reconcileNewDB
    - persist source user creds to secret at end of newdb for migration
    - bind psql containers to host IP so they can talk to each other
    - refactor ways credentials are divined from cluster
    - move mock sql roles into testdb runner
    - systemfunctions cleanup logic and logs
    - ignore errors during dbproxy shutdown