### PR TITLE
DEVOPS-28607 refuse to start if env is not passed in

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -182,6 +182,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if len(ctlConfig.GetString("env")) == 0 {
+		setupLog.Error(fmt.Errorf("empty_env"), "env must be set")
+		os.Exit(1)
+	}
+
 	namespace := os.Getenv("SERVICE_NAMESPACE")
 	if len(namespace) == 0 {
 		setupLog.Error(fmt.Errorf("empty_namespace"), "namespace must be set")


### PR DESCRIPTION
    db-controller is creating objects in a shared account. It
    must name these objects with a unique identifier which is
    the env of the cluster. Within a cluster, all objects are
    already unique.