### PR TITLE
Fix duplicate component labels

### DIFF
--- a/helm/db-controller/templates/_helpers.tpl
+++ b/helm/db-controller/templates/_helpers.tpl
@@ -42,6 +42,18 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
+{{- define "db-proxy-test.labels" -}}
+helm.sh/chart: {{ include "db-controller.chart" . }}
+app.kubernetes.io/name: {{ include "db-controller.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: dbproxy-test
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+
 {{/*
 Selector labels
 */}}

--- a/helm/db-controller/templates/deployment.yaml
+++ b/helm/db-controller/templates/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "db-controller.labels" . | nindent 4 }}
-    app.kubernetes.io/component: manager
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/helm/db-controller/templates/tests/dbproxy.yaml
+++ b/helm/db-controller/templates/tests/dbproxy.yaml
@@ -4,8 +4,7 @@ metadata:
   name: {{ .Release.Name }}-dbproxy-test
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "db-controller.labels" . | nindent 4 }}
-    app.kubernetes.io/component: dbproxy-test
+    {{- include "db-proxy-test.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": "test"
 ---
@@ -15,7 +14,7 @@ metadata:
   name: {{ .Release.Name }}-dbproxy-test
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "db-controller.labels" . | nindent 4 }}
+    {{- include "db-proxy-test.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": "test"
 rules:
@@ -34,7 +33,7 @@ metadata:
   name: {{ .Release.Name }}-dbproxy-test
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "db-controller.labels" . | nindent 4 }}
+    {{- include "db-proxy-test.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": "test"
 roleRef:
@@ -52,7 +51,7 @@ metadata:
   name: {{ .Release.Name }}-dbproxy-test
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "db-controller.labels" . | nindent 4 }}
+    {{- include "db-proxy-test.labels" . | nindent 4 }}
   annotations:
     # ensure this runs on the new db-controller, not the existing one
     "helm.sh/hook": "test"
@@ -70,7 +69,7 @@ metadata:
   name: {{ .Release.Name }}-dbproxy-test
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "db-controller.labels" . | nindent 4 }}
+    {{- include "db-proxy-test.labels" . | nindent 4 }}
   annotations:
     # ensure this runs on the new db-controller, not the existing one
     "helm.sh/hook": "test"
@@ -100,7 +99,7 @@ metadata:
   name: {{ .Release.Name }}-dbproxy-test-db
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "db-controller.labels" . | nindent 4 }}
+    {{- include "db-proxy-test.labels" . | nindent 4 }}
 spec:
   selector:
     app: dbproxy-test-db
@@ -116,7 +115,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: dbproxy-test-db
-    {{- include "db-controller.labels" . | nindent 4 }}
+    {{- include "db-proxy-test.labels" . | nindent 4 }}
 spec:
   containers:
     - name: postgres
@@ -135,7 +134,7 @@ metadata:
   name: {{ .Release.Name }}-dbproxy-test
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "db-controller.labels" . | nindent 4 }}
+    {{- include "db-proxy-test.labels" . | nindent 4 }}
     persistance.atlas.infoblox.com/claim: {{ .Release.Name }}-dbproxy-test
     persistance.atlas.infoblox.com/class: {{ .Values.dbController.class | quote }}
     persistance.atlas.infoblox.com/dbproxy: enabled


### PR DESCRIPTION
Seeing the following error deploying the current chart
```
  message: |-
    Helm upgrade failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
      line 14: mapping key "app.kubernetes.io/component" already defined at line 11
```