### PR TITLE
PTEUDO-1693 automation of CRD disabling flux and helm pruning

### DIFF
--- a/helm/db-controller-crds/templates/NOTES.txt
+++ b/helm/db-controller-crds/templates/NOTES.txt
@@ -1,0 +1,3 @@
+Installed the CRDs for this application. Check the status of these CRDs.
+
+    kubectl api-resources --api-group=persistance.atlas.infoblox.com

--- a/helm/db-controller-crds/templates/_helpers.tpl
+++ b/helm/db-controller-crds/templates/_helpers.tpl
@@ -1,0 +1,68 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "db-controller-crds.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "db-controller-crds.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "db-controller-crds.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "db-controller-crds.labels" -}}
+helm.sh/chart: {{ include "db-controller-crds.chart" . }}
+{{ include "db-controller-crds.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "db-controller-crds.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "db-controller-crds.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "db-controller-crds.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "db-controller-crds.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "db-controller-crds.getCRDNames" -}}
+{{- range $path, $content := .Files.Glob "crds/*" }}
+  {{- $crd := fromYaml (toString $content) }} {{ $crd.metadata.name }}
+{{- end }}
+{{- end }}

--- a/helm/db-controller-crds/templates/crds.yaml
+++ b/helm/db-controller-crds/templates/crds.yaml
@@ -1,6 +1,0 @@
-{{- if .Values.crds.install }}
-{{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
-{{ $.Files.Get $path }}
----
-{{- end }}
-{{- end }}

--- a/helm/db-controller-crds/templates/hooks/pre-upgrade.yaml
+++ b/helm/db-controller-crds/templates/hooks/pre-upgrade.yaml
@@ -1,0 +1,84 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-hooks
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "db-controller-crds.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: "pre-install,pre-upgrade"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-hooks
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "db-controller-crds.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: "pre-install,pre-upgrade"
+rules:
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - "customresourcedefinitions/status"
+    verbs:
+      - update
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-hooks
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "db-controller-crds.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: "pre-install,pre-upgrade"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-hooks
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-hooks
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Release.Name }}-pre
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "db-controller-crds.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: "pre-install,pre-upgrade"
+spec:
+  serviceAccountName: {{ .Release.Name }}-hooks
+  containers:
+    - name: wait
+      image: {{ .Values.tools.kubectl.repository }}:{{ .Values.tools.kubectl.tag }}
+      command:
+        - /bin/bash
+        - -cxe
+        - |
+          # Tell Flux not to delete the CRDs
+          # https://fluxcd.io/flux/components/kustomize/kustomizations/#prune
+          kubectl label crd
+          {{- include "db-controller-crds.getCRDNames" . }} 'kustomize.toolkit.fluxcd.io/prune=disabled'
+          # Tell Helm not to delete the CRDs
+          # https://helm.sh/docs/howto/charts_tips_and_tricks/#tell-helm-not-to-uninstall-a-resource
+          kubectl annotate crd
+          {{- include "db-controller-crds.getCRDNames" . }} 'helm.sh/resource-policy=keep'
+  restartPolicy: Never
+---

--- a/helm/db-controller-crds/templates/tests/test-connection.yaml
+++ b/helm/db-controller-crds/templates/tests/test-connection.yaml
@@ -1,0 +1,17 @@
+{{- if false }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "db-controller-crds.fullname" . }}-test-connection"
+  labels:
+    {{- include "db-controller-crds.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "db-controller-crds.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never
+{{- end }}

--- a/helm/db-controller-crds/values.yaml
+++ b/helm/db-controller-crds/values.yaml
@@ -1,6 +1,5 @@
-crds:
-  # This is a hack to render CRDs even if they're installed
-  # Use this with caution as it will also uninstall CRDs
-  # We can now do this with CreateReplace in flux so
-  # this is being disabled.
-  install: false
+tools:
+  kubectl:
+    repository: bitnami/kubectl
+    pullPolicy: IfNotPresent
+    tag: 1.28.5


### PR DESCRIPTION
DEMO
```
client.go:486: [debug] Starting delete for "db-controller-crds-pre" Pod
wait.go:66: [debug] beginning wait for 1 resources to be deleted with timeout of 5m0s
client.go:142: [debug] creating 1 resource(s)
client.go:712: [debug] Watching for changes to Pod db-controller-crds-pre with timeout of 5m0s
client.go:740: [debug] Add/Modify event for db-controller-crds-pre: ADDED
client.go:799: [debug] Pod db-controller-crds-pre pending
client.go:740: [debug] Add/Modify event for db-controller-crds-pre: MODIFIED
client.go:799: [debug] Pod db-controller-crds-pre pending
client.go:740: [debug] Add/Modify event for db-controller-crds-pre: MODIFIED
client.go:799: [debug] Pod db-controller-crds-pre pending
client.go:740: [debug] Add/Modify event for db-controller-crds-pre: MODIFIED
client.go:799: [debug] Pod db-controller-crds-pre pending
client.go:740: [debug] Add/Modify event for db-controller-crds-pre: MODIFIED
client.go:794: [debug] Pod db-controller-crds-pre succeeded
client.go:393: [debug] checking 0 resources for changes
client.go:442: [debug] Deleting CustomResourceDefinition "databaseclaims.persistance.atlas.infoblox.com" in namespace ...
client.go:453: [debug] Skipping delete of "databaseclaims.persistance.atlas.infoblox.com" due to annotation [helm.sh/resource-policy=keep]
client.go:442: [debug] Deleting CustomResourceDefinition "dbroleclaims.persistance.atlas.infoblox.com" in namespace ...
client.go:453: [debug] Skipping delete of "dbroleclaims.persistance.atlas.infoblox.com" due to annotation [helm.sh/resource-policy=keep]
upgrade.go:428: [debug] waiting for release db-controller-crds resources (created: 0 updated: 0  deleted: 0)
wait.go:48: [debug] beginning wait for 0 resources with timeout of 5m0s
upgrade.go:171: [debug] updating status for upgraded release for db-controller-crds
Release "db-controller-crds" has been upgraded. Happy Helming!
```