### PR TITLE
PTEUDO-2041 Support SSL and non-SSL client connections

### DIFF
--- a/dbproxy/pgbouncer/config.go
+++ b/dbproxy/pgbouncer/config.go
@@ -174,6 +174,11 @@ func parseURI(c *PGBouncerConfig, dsn string) error {
 	return nil
 }
 
+// As this is a local node connection, we will support non-SSL connections by using
+// the default client SSLMode of prefer. This will allow the client to connect to
+// the server using SSL if the server supports it, otherwise it will connect without SSL.
+// https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS
+
 const templateText = `
 [databases]
 {{.LocalDbName}} = host={{.RemoteHost}} port={{.RemotePort}} dbname={{.LocalDbName}}
@@ -189,7 +194,7 @@ admin_users = {{.UserName}}
 remote_user_override = {{.UserName}}
 remote_db_override = {{.LocalDbName}}
 ignore_startup_parameters = extra_float_digits
-client_tls_sslmode = disable
+client_tls_sslmode = prefer
 client_tls_key_file=dbproxy-client.key
 client_tls_cert_file=dbproxy-client.crt
 server_tls_sslmode = {{.SSLMode}}

--- a/dbproxy/scripts/start-pgbouncer.sh
+++ b/dbproxy/scripts/start-pgbouncer.sh
@@ -16,8 +16,15 @@ openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout dbproxy-clie
 
 pgbouncer -d -v pgbouncer.ini
 
-until timeout 10 psql -h localhost -c 'SELECT 1'; do
+# Test that both SSL and non-SSL connections work
+until timeout 10 psql postgres://localhost:5432/?sslmode=require -c 'SELECT 1'; do
   echo "Waiting for PostgreSQL to be ready..."
   sleep 1
 done
+
+until timeout 10 psql postgres://localhost:5432/?sslmode=disable -c 'SELECT 1'; do
+  echo "Waiting for PostgreSQL to be ready..."
+  sleep 1
+done
+
 echo "PostgreSQL is ready!"


### PR DESCRIPTION
    The dbproxy is used on the same host as the client. As SSL would
    be more secure, we already using SSL to secure the outbound
    connection to cloud or actual database. Since this sidecar call
    is local to the host, we will allow non-SSL connections. This will
    ensure better usability for users of dbproxy.