### PR TITLE
PTEUDO-2095: DB role claim username should be optional

### DIFF
--- a/api/v1/dbroleclaim_types.go
+++ b/api/v1/dbroleclaim_types.go
@@ -89,7 +89,7 @@ type DbRoleClaimStatus struct {
 	// Time the schemas and roles were updated
 	SchemasRolesUpdatedAt *metav1.Time `json:"schemasrolesupdatedat,omitempty"`
 
-	Username string `json:"username"`
+	Username string `json:"username,omitempty"`
 
 	// +patchMergeKey=type
 	// +patchStrategy=merge

--- a/config/crd/bases/persistance.atlas.infoblox.com_dbroleclaims.yaml
+++ b/config/crd/bases/persistance.atlas.infoblox.com_dbroleclaims.yaml
@@ -187,8 +187,6 @@ spec:
                 type: string
               username:
                 type: string
-            required:
-            - username
             type: object
         type: object
     served: true


### PR DESCRIPTION
```text
The DbRoleClaim CR expects the status.username  field to be set. 
However, some older version of the db-controller does not handle setting the status.username. 
To address this, we should make the DbRoleClaimStatus.username field optional.
```