### PR TITLE
PTEUDO-1989 - Fix migration trigger check.

### DIFF
--- a/pkg/databaseclaim/databaseclaim.go
+++ b/pkg/databaseclaim/databaseclaim.go
@@ -461,7 +461,7 @@ func (r *DatabaseClaimReconciler) reconcileUseExistingDB(ctx context.Context, re
 
 	err = r.manageUserAndExtensions(ctx, reqInfo, logr, dbClient, &dbClaim.Status.NewDB, dbName, dbClaim.Spec.Username, operationalMode)
 	if err != nil {
-		logr.Error(err, "unable to update users, user credents not persisted to status object")
+		logr.Error(err, "unable to update users, user credentials not persisted to status object")
 		return err
 	}
 	if err = r.updateClientStatus(ctx, dbClaim); err != nil {

--- a/pkg/hostparams/hostparams.go
+++ b/pkg/hostparams/hostparams.go
@@ -146,9 +146,8 @@ func New(config *viper.Viper, dbClaim *v1.DatabaseClaim) (*HostParams, error) {
 	if hostParams.DBVersion == "" {
 		// If we're managing an existing database, use its version.
 		if dbClaim.Spec.UseExistingSource != nil && *dbClaim.Spec.UseExistingSource {
-			if dbClaim.Status.ActiveDB.DBVersion != "" {
-				hostParams.DBVersion = dbClaim.Status.ActiveDB.DBVersion
-			} else {
+			hostParams.DBVersion = dbClaim.Status.ActiveDB.DBVersion
+			if hostParams.DBVersion == "" {
 				hostParams.IsDefaultVersion = true
 				hostParams.DBVersion = defaultMajorVersion
 			}

--- a/pkg/hostparams/hostparams.go
+++ b/pkg/hostparams/hostparams.go
@@ -144,15 +144,10 @@ func New(config *viper.Viper, dbClaim *v1.DatabaseClaim) (*HostParams, error) {
 	}
 
 	if hostParams.DBVersion == "" {
-		// If we're managing an existing database, use its version.
 		if dbClaim.Spec.UseExistingSource != nil && *dbClaim.Spec.UseExistingSource {
 			hostParams.DBVersion = dbClaim.Status.ActiveDB.DBVersion
-			if hostParams.DBVersion == "" {
-				hostParams.IsDefaultVersion = true
-				hostParams.DBVersion = defaultMajorVersion
-			}
-		} else {
-			// For new databases or migrations, use a default version.
+		}
+		if hostParams.DBVersion == "" {
 			hostParams.IsDefaultVersion = true
 			hostParams.DBVersion = defaultMajorVersion
 		}


### PR DESCRIPTION
- [PTEUDO-1989](https://infoblox.atlassian.net/browse/PTEUDO-1989);
- The issue was that the dbversion value was being retrieved from the previously set activedb source, even when `useExistingSource` was false. This caused the dbversion to keep having the activedb dbversion, and the migration was not triggered. This PR fixes it by checking whether `useExistingSource` is true or false.