### PR TITLE
PTEUDO-2142 remove validation of DSNName

### DIFF
--- a/internal/controller/databasecontroller_migrate_test.go
+++ b/internal/controller/databasecontroller_migrate_test.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	persistancev1 "github.com/infobloxopen/db-controller/api/v1"
+	v1 "github.com/infobloxopen/db-controller/api/v1"
 	"github.com/infobloxopen/db-controller/internal/dockerdb"
 	"github.com/infobloxopen/db-controller/pkg/hostparams"
 	"github.com/infobloxopen/db-controller/pkg/pgctl"
@@ -152,7 +153,7 @@ var _ = Describe("claim migrate", func() {
 					Namespace: "default",
 				},
 				StringData: map[string]string{
-					"uri_dsn.txt": testDSN,
+					v1.DSNURIKey: testDSN,
 				},
 				Type: "Opaque",
 			}

--- a/internal/dockerdb/testdb.go
+++ b/internal/dockerdb/testdb.go
@@ -282,6 +282,8 @@ CREATE ROLE alloydbsuperuser WITH INHERIT LOGIN`)
 		logger.Info(string(out))
 		os.Exit(1)
 	}
+
+	dsn = strings.Replace(dsn, "localhost", "127.0.0.1", 1)
 	// TODO: change this to debug logging, just timing jenkins for now
 	logger.Info("db_connected", "dsn", dsn, "duration", time.Since(now))
 

--- a/pkg/databaseclaim/databaseclaim.go
+++ b/pkg/databaseclaim/databaseclaim.go
@@ -19,7 +19,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "github.com/infobloxopen/db-controller/api/v1"
 	"github.com/infobloxopen/db-controller/pkg/auth"
@@ -146,12 +145,9 @@ func (r *DatabaseClaimReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	if err := validateDBClaim(&dbClaim); err != nil {
-		res, err := r.manageError(ctx, &dbClaim, err)
-		if dbClaim.Status.Error != "" {
-			metrics.ErrorStateClaims.Inc()
-		}
-		// TerminalError, do not requeue
-		return res, reconcile.TerminalError(err)
+		// Validation is weak until all apps are moved to new API
+		logr.Error(err, "dbclaim_failed_validation")
+		// FIXME: mark the claim status as error
 	}
 
 	if dbClaim.Spec.Class == nil {

--- a/pkg/databaseclaim/secrets_test.go
+++ b/pkg/databaseclaim/secrets_test.go
@@ -87,7 +87,19 @@ func TestUpdateSecret(t *testing.T) {
 		Data: make(map[string][]byte),
 	}
 
-	err := dbClaimReconciler.updateSecret(ctx, "dsn", "dsnUri", "ro_dsnUri", &claimConnInfo, &secret)
+	dbClaim := v1.DatabaseClaim{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dbClaim",
+			Namespace: "testNamespace",
+		},
+		Spec: v1.DatabaseClaimSpec{
+			SecretName: "create-master-secret",
+		},
+		Status: v1.DatabaseClaimStatus{},
+	}
+
+	err := dbClaimReconciler.updateSecret(ctx, &dbClaim, "dsn", "dsnUri", "ro_dsnUri", &claimConnInfo, &secret)
 
 	Expect(secret.Data[v1.DSNKey]).To(Equal([]byte("dsn")))
 	Expect(secret.Data[v1.DSNURIKey]).To(Equal([]byte("dsnUri")))


### PR DESCRIPTION
    Previously, customizing the dsnname would throw a validation error
    and prevent any processing of the databaseclaim. This allows the
    customization but ensures the normalized fields are always
    populated.


https://infoblox.atlassian.net/browse/PTEUDO-2142