### PR TITLE
PTEUDO-1602: DBRoleClaim Tests Update

### DIFF
--- a/internal/controller/dbroleclaim_controller_test.go
+++ b/internal/controller/dbroleclaim_controller_test.go
@@ -18,11 +18,14 @@ package controller
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/aws/smithy-go/ptr"
 	"github.com/go-logr/logr"
 	persistancev1 "github.com/infobloxopen/db-controller/api/v1"
 	_ "github.com/lib/pq"
@@ -32,7 +35,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -43,19 +49,45 @@ import (
 var _ = Describe("RoleClaim Controller", Ordered, func() {
 
 	const resourceName = "test-resource"
+	const newNamespace = "test-namespace-2"
+	const claimSecretName = "migrate-dbclaim-creds"
+
+	var (
+		ctxLogger context.Context
+		cancel    func()
+	)
+
+	const sourceSecretName = "postgres-source"
+	var migratedowner = "migrate"
 
 	ctx := context.Background()
+	claim := &persistancev1.DatabaseClaim{}
 
 	typeNamespacedName := types.NamespacedName{
 		Name:      resourceName,
 		Namespace: "default",
 	}
+
+	typeNamespacedDBResourceName := types.NamespacedName{
+		Name:      resourceName,
+		Namespace: "default",
+	}
+
 	typeNamespacedClaimName := types.NamespacedName{
 		Name:      "testdbclaim",
 		Namespace: "default",
 	}
 	typeNamespacedSecretName := types.NamespacedName{
 		Name:      "master-secret",
+		Namespace: "default",
+	}
+	typeNamespacedSourceSecretName := types.NamespacedName{
+		Name:      sourceSecretName,
+		Namespace: "default",
+	}
+
+	typeNamespacedClaimSecretName := types.NamespacedName{
+		Name:      claimSecretName,
 		Namespace: "default",
 	}
 
@@ -70,9 +102,80 @@ var _ = Describe("RoleClaim Controller", Ordered, func() {
 	viperObj.Set("defaultSslMode", "disable")
 
 	BeforeEach(func() {
+		ctxLogger, cancel = context.WithCancel(context.Background())
+		ctxLogger = log.IntoContext(ctxLogger, NewGinkgoLogger())
+
+		By("Creating the custom resource for the Kind DatabaseClaim if not present")
+		err := k8sClient.Get(ctx, typeNamespacedDBResourceName, claim)
+		if err != nil && errors.IsNotFound(err) {
+			claim = &persistancev1.DatabaseClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: persistancev1.DatabaseClaimSpec{
+					Class:                 ptr.To(""),
+					DatabaseName:          "postgres",
+					SecretName:            claimSecretName,
+					EnableSuperUser:       ptr.To(false),
+					EnableReplicationRole: ptr.To(false),
+					UseExistingSource:     ptr.To(true),
+					Type:                  "postgres",
+					SourceDataFrom: &persistancev1.SourceDataFrom{
+						Type: "database",
+						Database: &persistancev1.Database{
+							SecretRef: &persistancev1.SecretRef{
+								Name: sourceSecretName,
+
+								Namespace: "default",
+							},
+						},
+					},
+					Username: migratedowner,
+				},
+			}
+			Expect(k8sClient.Create(ctx, claim)).To(Succeed())
+		}
+
+		By("creating the custom resource for the Kind DatabaseClaim")
+		_, err = url.Parse(testDSN)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client.IgnoreNotFound(err)).To(Succeed())
+
+		By("Creating the source master creds")
+		srcSecret := &corev1.Secret{}
+		err = k8sClient.Get(ctxLogger, typeNamespacedSourceSecretName, srcSecret)
+		if err != nil && errors.IsNotFound(err) {
+			srcSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sourceSecretName,
+					Namespace: "default",
+				},
+				StringData: map[string]string{
+					"uri_dsn.txt": testDSN,
+				},
+				Type: "Opaque",
+			}
+			Expect(k8sClient.Create(ctxLogger, srcSecret)).To(Succeed())
+		}
+
+		By("Create a new Namespace for creation new Role Claim if not present")
+		namespace := &corev1.Namespace{}
+		err = k8sClient.Get(ctx, types.NamespacedName{Name: newNamespace}, namespace)
+		if err != nil && errors.IsNotFound(err) {
+			namespace = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: newNamespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
+		} else {
+			Expect(err).NotTo(HaveOccurred())
+		}
+
 		dbroleclaim := &persistancev1.DbRoleClaim{}
 		By("creating the custom resource for the Kind DbRoleClaim")
-		err := k8sClient.Get(ctx, typeNamespacedName, dbroleclaim)
+		err = k8sClient.Get(ctx, typeNamespacedName, dbroleclaim)
 		if err != nil && errors.IsNotFound(err) {
 			resource := &persistancev1.DbRoleClaim{
 				ObjectMeta: metav1.ObjectMeta{
@@ -85,7 +188,7 @@ var _ = Describe("RoleClaim Controller", Ordered, func() {
 						Name:      "testdbclaim",
 					},
 					SecretName: "copy-secret",
-					Class:      ptr.String("default"),
+					Class:      ptr.To("default"),
 				},
 				Status: persistancev1.DbRoleClaimStatus{},
 			}
@@ -106,7 +209,7 @@ var _ = Describe("RoleClaim Controller", Ordered, func() {
 						Name:      "testclaim",
 					},
 					SecretName: "copy-secret",
-					Class:      ptr.String("default"),
+					Class:      ptr.To("default"),
 					SchemaRoleMap: map[string]persistancev1.RoleType{
 						"schema0": "",
 					},
@@ -126,7 +229,7 @@ var _ = Describe("RoleClaim Controller", Ordered, func() {
 				},
 				Spec: persistancev1.DatabaseClaimSpec{
 					SecretName: "master-secret",
-					Class:      ptr.String("default"),
+					Class:      ptr.To("default"),
 					Username:   "user1",
 				},
 				Status: persistancev1.DatabaseClaimStatus{},
@@ -154,6 +257,33 @@ var _ = Describe("RoleClaim Controller", Ordered, func() {
 			}
 			Expect(k8sClient.Create(ctx, sec)).To(Succeed())
 		}
+
+		By("Getting the DatabaseClaim resource created in the default namespace")
+		err = k8sClient.Get(ctx, typeNamespacedDBResourceName, claim)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating the custom resource for the Kind DbRoleClaim in the new namespace")
+		dbroleclaimdiffnamespace := &persistancev1.DbRoleClaim{}
+		err = k8sClient.Get(ctx, types.NamespacedName{Name: resourceName, Namespace: newNamespace}, dbroleclaimdiffnamespace)
+		if err != nil && errors.IsNotFound(err) {
+			dbroleclaimdiffnamespace = &persistancev1.DbRoleClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: newNamespace,
+				},
+				Spec: persistancev1.DbRoleClaimSpec{
+					SourceDatabaseClaim: &persistancev1.SourceDatabaseClaim{
+						Name:      claim.Name,      // Claim is created in the default namespace and used as source
+						Namespace: claim.Namespace, // Claim is created in the default namespace and used as source
+					},
+					SecretName: "copy-secret",
+				},
+			}
+			Expect(k8sClient.Create(ctx, dbroleclaimdiffnamespace)).To(Succeed())
+		} else {
+			Expect(err).NotTo(HaveOccurred())
+		}
+
 	})
 
 	AfterEach(func() {
@@ -164,30 +294,79 @@ var _ = Describe("RoleClaim Controller", Ordered, func() {
 		By("Cleanup the specific resource instance DbRoleClaim")
 		Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 
-		err = k8sClient.Get(ctx, typeNamespacedNameInvalidParam, resource)
-		Expect(err).NotTo(HaveOccurred())
-		By("Cleanup the specific resource instance DbRoleClaim")
-		Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		By("Cleanup the specific resource instance DatabaseClaim")
+		dbroleclaim := &persistancev1.DatabaseClaim{}
+		err = k8sClient.Get(ctx, typeNamespacedDBResourceName, dbroleclaim)
+		fmt.Println("Error: ", err)
+		Expect(k8sClient.Delete(ctx, dbroleclaim)).To(Succeed())
+		cancel()
 
 	})
 
 	It("should successfully reconcile the resource", func() {
-		By("Reconciling the created resource")
+		By("Reconciling the created claim in default namespace")
+		_, err := controllerReconciler.Reconcile(ctxLogger, reconcile.Request{NamespacedName: typeNamespacedDBResourceName})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(claim.Status.Error).To(Equal(""))
 
-		controllerReconciler := &DbRoleClaimReconciler{
+		By("Ensuring the active db connection info is set")
+		Eventually(func() *persistancev1.DatabaseClaimConnectionInfo {
+			Expect(k8sClient.Get(ctxLogger, typeNamespacedName, claim)).NotTo(HaveOccurred())
+			return claim.Status.ActiveDB.ConnectionInfo
+		}).ShouldNot(BeNil())
+
+		By("Ensuring NewDb is reset to nil")
+		Expect(claim.Status.NewDB.ConnectionInfo).To(BeNil())
+
+		By("Ensuring the status activedb connection info is set correctly")
+		u, err := url.Parse(testDSN)
+		Expect(err).NotTo(HaveOccurred())
+		aConn := claim.Status.ActiveDB.ConnectionInfo
+		Expect(aConn.Host).To(Equal(u.Hostname()))
+		Expect(aConn.Port).To(Equal(u.Port()))
+		Expect(aConn.Username).To(Equal(migratedowner + "_a"))
+		Expect(aConn.DatabaseName).To(Equal(strings.TrimPrefix(u.Path, "/")))
+		Expect(aConn.SSLMode).To(Equal(u.Query().Get("sslmode")))
+
+		activeURI, err := url.Parse(aConn.Uri())
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Checking the DSN in the secret")
+		redacted := activeURI.Redacted()
+		var creds corev1.Secret
+		Expect(k8sClient.Get(ctxLogger, typeNamespacedClaimSecretName, &creds)).NotTo(HaveOccurred())
+		Expect(creds.Data[persistancev1.DSNURIKey]).ToNot(BeNil())
+		dsn, err := url.Parse(string(creds.Data[persistancev1.DSNURIKey]))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dsn.Redacted()).To(Equal(redacted))
+
+		By("Ensuring the active db connection info is set")
+		Eventually(func() *persistancev1.DatabaseClaimConnectionInfo {
+			Expect(k8sClient.Get(ctxLogger, typeNamespacedName, claim)).NotTo(HaveOccurred())
+			return claim.Status.ActiveDB.ConnectionInfo
+		}).ShouldNot(BeNil())
+
+		By("Getting the newly created Namespace resource")
+		namespace := &corev1.Namespace{}
+		err = k8sClient.Get(ctx, types.NamespacedName{Name: newNamespace}, namespace)
+		fmt.Println("Namespace Name:", namespace.Name)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating a DBRoleclaim reconciler")
+		dbroleclaimreconciler := &DbRoleClaimReconciler{
 			Client: k8sClient,
 			Config: &roleclaim.RoleConfig{
 				Viper:     viperObj,
 				Namespace: "default",
 			},
 		}
-
-		controllerReconciler.Reconciler = &roleclaim.DbRoleClaimReconciler{
-			Client: controllerReconciler.Client,
-			Config: controllerReconciler.Config,
+		dbroleclaimreconciler.Reconciler = &roleclaim.DbRoleClaimReconciler{
+			Client: dbroleclaimreconciler.Client,
+			Config: dbroleclaimreconciler.Config,
 		}
 
-		_, err := controllerReconciler.Reconciler.Reconcile(ctx, reconcile.Request{
+		By("Reconciling the created resource")
+		_, err = dbroleclaimreconciler.Reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: typeNamespacedName,
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -200,6 +379,57 @@ var _ = Describe("RoleClaim Controller", Ordered, func() {
 		err = k8sClient.Get(ctx, secretName, secret)
 
 		Expect(err).NotTo(HaveOccurred())
+
+		By("Reconciling the created DbRoleClaim resource in new namespace")
+		_, err = dbroleclaimreconciler.Reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      resourceName,
+				Namespace: newNamespace,
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Getting the DbRoleClaim resource created in the new namespace")
+		dbroleclaimdiffnamespace := &persistancev1.DbRoleClaim{}
+		err = k8sClient.Get(ctx, types.NamespacedName{Name: resourceName, Namespace: newNamespace}, dbroleclaimdiffnamespace)
+		fmt.Printf("Status of DbRoleClaim: %+v", dbroleclaimdiffnamespace.Status)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Checking the secret in the new namespace")
+		secretName = types.NamespacedName{
+			Name:      "copy-secret",
+			Namespace: newNamespace,
+		}
+		err = k8sClient.Get(ctx, secretName, secret)
+		Expect(err).NotTo(HaveOccurred())
+
+		fmt.Printf("Secret Name: %s, Secret Data: %s", secret.Name, secret.Data)
+		dsnString := string(secret.Data["uri_dsn.txt"])
+
+		By("Opening a connection to the database using the DSN from the secret in the new namespace")
+		db, err := sql.Open("postgres", dsnString)
+		if err == nil {
+			fmt.Println("Connection to the database successful")
+		}
+		Expect(err).NotTo(HaveOccurred())
+		defer db.Close()
+
+		By("Running the query to get the tables in the new namespace")
+		rows, err := db.Query("SELECT tablename, tableowner, pg_size_pretty(pg_total_relation_size(tablename::text)) AS size, obj_description(pg_class.oid) AS description FROM pg_tables JOIN pg_class ON tablename = relname WHERE schemaname = 'public'")
+		Expect(err).NotTo(HaveOccurred())
+		defer rows.Close()
+		for rows.Next() {
+			var tableName, tableOwner, tableSize string
+			var tableDescription sql.NullString
+			err := rows.Scan(&tableName, &tableOwner, &tableSize, &tableDescription)
+			Expect(err).NotTo(HaveOccurred())
+			description := ""
+			if tableDescription.Valid {
+				description = tableDescription.String
+			}
+			fmt.Printf("Table: %s, Owner: %s, Size: %s, Description: %s", tableName, tableOwner, tableSize, description)
+		}
+		Expect(rows.Err()).NotTo(HaveOccurred())
 	})
 
 	It("should fail to reconcile the resource", func() {


### PR DESCRIPTION
Added the following new DbRoleClaim Tests , creating a roleclaim in new namespace for a Dbclaim existing in another namespace

Output of running test
```
STEP: Opening a connection to the database using the DSN from the secret in the new namespace 
Connection to the database successful
STEP: Running the query to get the tables in the new namespace 
Table: users, Owner: postgres, Size: 16 kB, Description:   
< Exit [It] should successfully reconcile the resource 
……..
[AfterSuite] PASSED [1.126 seconds]
------------------------------

Ran 2 of 11 Specs in 5.742 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 9 Skipped
PASS
ok      github.com/infobloxopen/db-controller/internal/controller       6.667s
```


