### PR TITLE
update start-pgbouncer to exit after 60seconds

### DIFF
--- a/dbproxy/scripts/start-pgbouncer.sh
+++ b/dbproxy/scripts/start-pgbouncer.sh
@@ -5,26 +5,65 @@ set -e
 command -v pgbouncer
 set +e
 
-until  timeout 10 psql "$(cat /dbproxy/uri_dsn.txt)" -c 'SELECT 1'; do
-  echo "Waiting for PostgreSQL to be ready..."
-  sleep 1
-done
-echo "PostgreSQL is ready!"
+# Function to test PostgreSQL connection
+test_postgres() {
+    local dsn="$1"
+    if psql "$dsn" -c 'SELECT 1' >/dev/null 2>&1; then
+        return 0
+    fi
+    return 1
+}
 
+# Function to run all connection tests with global timeout
+run_connection_tests() {
+    local start_time=$(date +%s)
+    local timeout=60
+    local ssl_ok=0
+    local nonssl_ok=0
+
+    while [ $ssl_ok -eq 0 ] || [ $nonssl_ok -eq 0 ]; do
+        current_time=$(date +%s)
+        if [ $((current_time - start_time)) -ge $timeout ]; then
+            echo "Timed out waiting for PostgreSQL after ${timeout} seconds"
+            return 1
+        fi
+
+        if [ $ssl_ok -eq 0 ] && test_postgres "postgres://localhost:5432/?sslmode=require"; then
+            echo "SSL connection successful"
+            ssl_ok=1
+        fi
+
+        if [ $nonssl_ok -eq 0 ] && test_postgres "postgres://localhost:5432/?sslmode=disable"; then
+            echo "Non-SSL connection successful"
+            nonssl_ok=1
+        fi
+
+        if [ $ssl_ok -eq 0 ] || [ $nonssl_ok -eq 0 ]; then
+            echo "Waiting for PostgreSQL connections to be ready..."
+            sleep 2
+        fi
+    done
+    return 0
+}
+
+# Initial PostgreSQL check
+if ! test_postgres "$(cat /dbproxy/uri_dsn.txt)"; then
+    echo "Initial PostgreSQL connection failed"
+    exit 1
+fi
+echo "Initial PostgreSQL connection successful!"
+
+# Generate certificates
 openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout dbproxy-server.key -out dbproxy-server.crt -subj "/C=US/CN=dbproxy-server/ST=CA/L=Santa Clara/O=Infoblox/OU=Blox in a Box"
 openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout dbproxy-client.key -out dbproxy-client.crt -subj "/C=US/CN=dbproxy-client/ST=CA/L=Santa Clara/O=Infoblox/OU=Blox in a Box"
 
+# Start pgbouncer
 pgbouncer -d -v pgbouncer.ini
 
-# Test that both SSL and non-SSL connections work
-until timeout 10 psql postgres://localhost:5432/?sslmode=require -c 'SELECT 1'; do
-  echo "Waiting for PostgreSQL to be ready..."
-  sleep 1
-done
+# Test both SSL and non-SSL connections concurrently
+if ! run_connection_tests; then
+    echo "Connection tests failed"
+    exit 1
+fi
 
-until timeout 10 psql postgres://localhost:5432/?sslmode=disable -c 'SELECT 1'; do
-  echo "Waiting for PostgreSQL to be ready..."
-  sleep 1
-done
-
-echo "PostgreSQL is ready!"
+echo "All PostgreSQL connections are ready!"


### PR DESCRIPTION
DEMO
ran the test and watched pods stay ready/live for 15 password cycles
```
~ ❯ k -n dwells describe po dwells-dbproxy-test | tail -n15
Events:
  Type     Reason                           Age                 From      Message
  ----     ------                           ----                ----      -------
  Normal   Scheduled                        46m                 trimaran  Successfully assigned dwells/dwells-dbproxy-test to ip-172-60-1-11.ec2.internal
  Normal   Pulled                           46m                 kubelet   Container image "harbor.services.sdp.infoblox.com/proxy_cache_docker_hub/postgres:15" already present on machine
  Normal   Created                          46m                 kubelet   Created container init
  Normal   Started                          46m                 kubelet   Started container init
  Normal   Pulled                           46m                 kubelet   Container image "harbor.services.sdp.infoblox.com/infobloxcto/kubectl:1.28.5" already present on machine
  Normal   Created                          46m                 kubelet   Created container wait
  Normal   Started                          46m                 kubelet   Started container wait
  Normal   Pulling                          46m                 kubelet   Pulling image "ghcr.io/infobloxopen/dbproxy:v1.10.1-9-g3975244"
  Normal   Pulled                           46m                 kubelet   Successfully pulled image "ghcr.io/infobloxopen/dbproxy:v1.10.1-9-g3975244" in 921ms (921ms including waiting)
  Normal   Created                          46m                 kubelet   Created container dbproxy
  Normal   Started                          46m                 kubelet   Started container dbproxy
  Warning  FailedToRetrieveImagePullSecret  37s (x41 over 46m)  kubelet   Unable to retrieve some image pull secrets (regsecret); attempting to pull the image may not succeed.
```