### PR TITLE
DEVOPS-30870: fix password rotation logic

### DIFF
--- a/internal/controller/databaseclaim_controller_test.go
+++ b/internal/controller/databaseclaim_controller_test.go
@@ -116,9 +116,9 @@ var _ = Describe("DatabaseClaim Controller", func() {
 			By("Mocking master credentials")
 			hostParams, err := hostparams.New(controllerReconciler.Config.Viper, resource)
 			Expect(err).ToNot(HaveOccurred())
-
+			// postgres-db.t4g.medium-15
 			credSecretName := fmt.Sprintf("%s-%s-%s", env, resourceName, hostParams.Hash())
-
+			Expect(credSecretName).To(Equal("testenv-test-dbclaim-416e183c"))
 			cleanup := dockerdb.MockRDSCredentials(GinkgoT(), ctx, k8sClient, testDSN, credSecretName)
 			DeferCleanup(cleanup)
 
@@ -205,21 +205,26 @@ var _ = Describe("DatabaseClaim Controller", func() {
 			resource.Spec.DBVersion = "13.3"
 			Expect(k8sClient.Update(ctx, resource)).NotTo(HaveOccurred())
 
+			hostParams, err := hostparams.New(controllerReconciler.Config.Viper, resource)
+			Expect(err).ToNot(HaveOccurred())
+
+			credSecretName := fmt.Sprintf("%s-%s-%s", env, resourceName, hostParams.Hash())
+			// testenv-test-dbclaim-416e183c
+			cleanup := dockerdb.MockRDSCredentials(GinkgoT(), ctx, k8sClient, testDSN, credSecretName)
+			DeferCleanup(cleanup)
+			Expect(credSecretName).To(Equal("testenv-test-dbclaim-15387708"))
+
 			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).NotTo(HaveOccurred())
 			Expect(resource.Spec.DBVersion).To(Equal("13.3"))
 
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resource.Status.Error).To(Equal(""))
-
-			var instance crossplaneaws.DBInstance
-			viper := controllerReconciler.Config.Viper
-			hostParams, err := hostparams.New(viper, resource)
-			Expect(err).ToNot(HaveOccurred())
 
 			instanceName := fmt.Sprintf("%s-%s-%s", env, resourceName, hostParams.Hash())
 
 			By(fmt.Sprintf("Check dbinstance is created: %s", instanceName))
+			var instance crossplaneaws.DBInstance
 			Eventually(func() error {
 				return k8sClient.Get(ctx, types.NamespacedName{Name: instanceName}, &instance)
 			}).Should(Succeed())
@@ -230,15 +235,45 @@ var _ = Describe("DatabaseClaim Controller", func() {
 
 			resource := &persistancev1.DatabaseClaim{}
 			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).NotTo(HaveOccurred())
-			resource.Spec.DBVersion = "13.3"
 			Expect(k8sClient.Update(ctx, resource)).NotTo(HaveOccurred())
 
 			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).NotTo(HaveOccurred())
-			Expect(resource.Spec.DBVersion).To(Equal("13.3"))
+			Expect(resource.Spec.DBVersion).To(Equal(""))
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
 			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).NotTo(HaveOccurred())
 			Expect(resource.Status.Error).To(Equal(""))
+
+		})
+
+		It("Reconcile rotates the username", func() {
+			By("Updating CR with a DB Version")
+
+			resource := &persistancev1.DatabaseClaim{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).NotTo(HaveOccurred())
+			Expect(resource.Spec.DBVersion).To(Equal(""))
+
+			By("Rotating to UserSuffixA")
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).NotTo(HaveOccurred())
+			Expect(resource.Status.Error).To(Equal(""))
+			Expect(resource.Status.ActiveDB.ConnectionInfo.Username).To(Equal("postgres_a"))
+
+			By("Rotating to UserSuffixB")
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).NotTo(HaveOccurred())
+			Expect(resource.Status.Error).To(Equal(""))
+			Expect(resource.Status.ActiveDB.ConnectionInfo.Username).To(Equal("postgres_b"))
+
+			By("Rotating to UserSuffixA")
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).NotTo(HaveOccurred())
+			Expect(resource.Status.Error).To(Equal(""))
+			Expect(resource.Status.ActiveDB.ConnectionInfo.Username).To(Equal("postgres_a"))
 
 		})
 

--- a/pkg/databaseclaim/databaseclaim.go
+++ b/pkg/databaseclaim/databaseclaim.go
@@ -1172,17 +1172,6 @@ func (r *DatabaseClaimReconciler) manageUserAndExtensions(ctx context.Context, r
 		return fmt.Errorf("newDB connection info is nil")
 	}
 
-	// The statusActiveDB is relevant only in the UseNewDB mode for now.
-	if operationalMode == M_UseNewDB {
-		if statusActiveDB == nil {
-			return fmt.Errorf("status activeDB is nil")
-		}
-
-		if statusActiveDB.ConnectionInfo == nil {
-			return fmt.Errorf("activeDB connection info is nil")
-		}
-	}
-
 	dbu := dbuser.NewDBUser(baseUsername)
 	rotationTime := r.getPasswordRotationTime()
 
@@ -1202,7 +1191,7 @@ func (r *DatabaseClaimReconciler) manageUserAndExtensions(ctx context.Context, r
 	}
 
 	currentUser := statusNewDB.ConnectionInfo.Username
-	if currentUser == "" && statusActiveDB.ConnectionInfo.Uri() != "" && operationalMode == M_UseNewDB {
+	if currentUser == "" && statusActiveDB.ConnectionInfo != nil && statusActiveDB.ConnectionInfo.Uri() != "" && operationalMode == M_UseNewDB {
 		logger.Info("using active db user", "active_db", statusActiveDB)
 		currentUser = statusActiveDB.ConnectionInfo.Username
 	}

--- a/pkg/databaseclaim/databaseclaim.go
+++ b/pkg/databaseclaim/databaseclaim.go
@@ -1221,7 +1221,7 @@ func (r *DatabaseClaimReconciler) manageUserAndExtensions(ctx context.Context, r
 	}
 
 	if statusNewDB.UserUpdatedAt == nil || time.Since(statusActiveDB.UserUpdatedAt.Time) >= rotationTime {
-		logger.V(1).Info("rotating user password",
+		logger.V(1).Info("rotating_user_password",
 			"currentUser", currentUser,
 			"dbu", dbu,
 			"statusNewDB", statusNewDB,

--- a/pkg/databaseclaim/databaseclaim.go
+++ b/pkg/databaseclaim/databaseclaim.go
@@ -1172,12 +1172,15 @@ func (r *DatabaseClaimReconciler) manageUserAndExtensions(ctx context.Context, r
 		return fmt.Errorf("newDB connection info is nil")
 	}
 
-	if statusActiveDB == nil {
-		return fmt.Errorf("status activeDB is nil")
-	}
+	// The statusActiveDB is relevant only in the UseNewDB mode for now.
+	if operationalMode == M_UseNewDB {
+		if statusActiveDB == nil {
+			return fmt.Errorf("status activeDB is nil")
+		}
 
-	if statusActiveDB.ConnectionInfo == nil {
-		return fmt.Errorf("activeDB connection info is nil")
+		if statusActiveDB.ConnectionInfo == nil {
+			return fmt.Errorf("activeDB connection info is nil")
+		}
 	}
 
 	dbu := dbuser.NewDBUser(baseUsername)

--- a/pkg/dbuser/dbuser.go
+++ b/pkg/dbuser/dbuser.go
@@ -9,12 +9,14 @@ const (
 	SuffixB = "_b"
 )
 
+// DBUser is a struct that holds the usernames for a given role.
 type DBUser struct {
 	rolename string
 	userA    string
 	userB    string
 }
 
+// NewDBUser returns a new DBUser instance.
 func NewDBUser(baseName string) DBUser {
 	return DBUser{
 		rolename: baseName,
@@ -23,6 +25,8 @@ func NewDBUser(baseName string) DBUser {
 	}
 }
 
+// IsUserChanged checks if the given currentUserName has changed compared to the
+// rolename of the DBUser instance.
 func (dbu DBUser) IsUserChanged(currentUserName string) bool {
 
 	if currentUserName == "" {
@@ -32,14 +36,17 @@ func (dbu DBUser) IsUserChanged(currentUserName string) bool {
 	return TrimUserSuffix(currentUserName) != dbu.rolename
 }
 
+// TrimUserSuffix removes the suffixes from the given string.
 func TrimUserSuffix(in string) string {
 	return strings.TrimSuffix(strings.TrimSuffix(in, SuffixA), SuffixB)
 }
 
+// GetUserA returns the username for UserA.
 func (dbu DBUser) GetUserA() string {
 	return dbu.userA
 }
 
+// GetUserB returns the username for UserB.
 func (dbu DBUser) GetUserB() string {
 	return dbu.userB
 }


### PR DESCRIPTION
- This PR fixes the user/password rotation logic that was broken;
- It fixes it by checking if the current user is empty and activeDB status struct has a URI, if yes, this means there is an activeDB already with an active user and not an initial database creation;
- Refer to: https://infoblox.atlassian.net/browse/PTEUDO-2215?focusedCommentId=4007818
