### PR TITLE
DEVOPS-30642 disable liveness probes

### DIFF
--- a/helm/db-controller/templates/tests/dbproxy.yaml
+++ b/helm/db-controller/templates/tests/dbproxy.yaml
@@ -70,6 +70,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "db-proxy-test.labels" . | nindent 4 }}
+    persistance.atlas.infoblox.com/allow-deletion: enabled
   annotations:
     # ensure this runs on the new db-controller, not the existing one
     "helm.sh/hook": "test"

--- a/helm/db-controller/templates/tests/dsnexec.yaml
+++ b/helm/db-controller/templates/tests/dsnexec.yaml
@@ -26,7 +26,7 @@ spec:
         - /bin/sh
         - -c
         - |
-          ls /etc/secrets
+          test -f /etc/secrets/uri_dsn.txt || { echo "Error: URI file does not exist"; exit 1; }
           cat /etc/secrets/uri_dsn.txt
           for i in $(seq 1 10); do
             echo "Attempt $i: Connecting to PostgreSQL..."

--- a/helm/db-controller/templates/tests/roleclaim.yaml
+++ b/helm/db-controller/templates/tests/roleclaim.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "db-controller.labels" . | nindent 4 }}
+    persistance.atlas.infoblox.com/allow-deletion: enabled
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-weight": "-4"

--- a/internal/webhook/dbproxy.go
+++ b/internal/webhook/dbproxy.go
@@ -8,6 +8,7 @@ import (
 )
 
 var (
+	// TODO: align this with the path used in dsnexec.go
 	MountPathProxy     = "/dbproxy"
 	VolumeNameProxy    = "dbproxydsn"
 	ContainerNameProxy = "dbproxy"

--- a/internal/webhook/dsnexec.go
+++ b/internal/webhook/dsnexec.go
@@ -78,13 +78,12 @@ func mutatePodExec(ctx context.Context, pod *corev1.Pod, secretName string, dsnE
 	var readinessProbe *corev1.Probe
 	if enableReady {
 		readinessProbe = &corev1.Probe{
-
 			ProbeHandler: corev1.ProbeHandler{
 				Exec: &corev1.ExecAction{
 					Command: []string{
 						"/bin/sh",
 						"-c",
-						"psql -h localhost -c \"SELECT 1\"",
+						fmt.Sprintf("psql \"$(cat %s/%s)\" -c \"SELECT 1\"", MountPathExec, SecretKey),
 					},
 				},
 			},
@@ -94,9 +93,10 @@ func mutatePodExec(ctx context.Context, pod *corev1.Pod, secretName string, dsnE
 		}
 	}
 
+	// FIXME: figure out a liveness probe for dsnexec
 	var livenessProbe *corev1.Probe
-
-	if enableLiveness {
+	_ = livenessProbe
+	if false && enableLiveness {
 		livenessProbe = &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				Exec: &corev1.ExecAction{
@@ -128,9 +128,9 @@ func mutatePodExec(ctx context.Context, pod *corev1.Pod, secretName string, dsnE
 				Value: fmt.Sprintf("%s/%s", MountPathExec, SecretKey),
 			},
 		},
-		// Test connection to upstream database
-		LivenessProbe: livenessProbe,
-		// Test connection to pgbouncer
+		// FIXME: figure out a liveness probe for dsnexec
+		// LivenessProbe: livenessProbe,
+		// Test connection to specified database
 		ReadinessProbe: readinessProbe,
 		VolumeMounts: []corev1.VolumeMount{
 			{

--- a/internal/webhook/dsnexec_test.go
+++ b/internal/webhook/dsnexec_test.go
@@ -126,7 +126,8 @@ var _ = Describe("dsnexec defaulting", func() {
 		Expect(sidecar.VolumeMounts[0].MountPath).To(Equal(MountPathExec))
 		Expect(sidecar.VolumeMounts[0].ReadOnly).To(BeTrue())
 		Expect(sidecar.ReadinessProbe).ToNot(BeNil())
-		Expect(sidecar.LivenessProbe).ToNot(BeNil())
+		// FIXME: liveness probes deactivated DEVOPS-30642
+		// Expect(sidecar.LivenessProbe).ToNot(BeNil())
 	})
 
 	It("pre-mutated pods are not re-mutated", func() {


### PR DESCRIPTION
    dsnexec does not use the standard mount volumes of dbproxy. So
    it can't use probes pointing to those mount volumes. Removed
    the liveness probe and setup the readiness probe to point
    to DBPROXY_CREDENTIAL env variable.


https://infoblox.atlassian.net/browse/DEVOPS-30642