### PR TITLE
Add CREATE privilege grant for schema in database permissions

### DIFF
--- a/pkg/dbclient/client.go
+++ b/pkg/dbclient/client.go
@@ -455,6 +455,7 @@ func (pc *client) CreateRole(dbName, rolename, schema string) (bool, error) {
 		grantPrivileges := `
 			GRANT ALL PRIVILEGES ON DATABASE %s TO %s;
 			GRANT ALL ON SCHEMA %s TO %s;
+			GRANT CREATE ON SCHEMA %s TO %s;
 			GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA %s TO %s;
 			GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %s TO %s;
 			GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA %s TO %s;
@@ -462,6 +463,7 @@ func (pc *client) CreateRole(dbName, rolename, schema string) (bool, error) {
 
 		_, err = db.Exec(fmt.Sprintf(grantPrivileges,
 			pq.QuoteIdentifier(dbName), pq.QuoteIdentifier(rolename),
+			pq.QuoteIdentifier(schema), pq.QuoteIdentifier(rolename),
 			pq.QuoteIdentifier(schema), pq.QuoteIdentifier(rolename),
 			pq.QuoteIdentifier(schema), pq.QuoteIdentifier(rolename),
 			pq.QuoteIdentifier(schema), pq.QuoteIdentifier(rolename),

--- a/pkg/dbclient/client.go
+++ b/pkg/dbclient/client.go
@@ -455,16 +455,12 @@ func (pc *client) CreateRole(dbName, rolename, schema string) (bool, error) {
 		grantPrivileges := `
 			GRANT ALL PRIVILEGES ON DATABASE %s TO %s;
 			GRANT ALL ON SCHEMA %s TO %s;
-			GRANT CREATE ON SCHEMA %s TO %s;
 			GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA %s TO %s;
 			GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %s TO %s;
-			GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA %s TO %s;
 		`
 
 		_, err = db.Exec(fmt.Sprintf(grantPrivileges,
 			pq.QuoteIdentifier(dbName), pq.QuoteIdentifier(rolename),
-			pq.QuoteIdentifier(schema), pq.QuoteIdentifier(rolename),
-			pq.QuoteIdentifier(schema), pq.QuoteIdentifier(rolename),
 			pq.QuoteIdentifier(schema), pq.QuoteIdentifier(rolename),
 			pq.QuoteIdentifier(schema), pq.QuoteIdentifier(rolename),
 			pq.QuoteIdentifier(schema), pq.QuoteIdentifier(rolename),
@@ -542,9 +538,6 @@ func (pc *client) CreateRegularRole(dbName, rolename, schema string) (bool, erro
 		-- Grant ALL privileges on all sequences
 		GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %s TO %s;
 		ALTER DEFAULT PRIVILEGES IN SCHEMA %s GRANT ALL PRIVILEGES ON SEQUENCES TO %s;
-
-		-- Grant ALL privileges on all functions
-		ALTER DEFAULT PRIVILEGES IN SCHEMA %s GRANT ALL PRIVILEGES ON FUNCTIONS TO %s;
 	`
 
 		db, err := pc.getDB(dbName)
@@ -558,7 +551,6 @@ func (pc *client) CreateRegularRole(dbName, rolename, schema string) (bool, erro
 		_, err = db.Exec(
 			fmt.Sprintf(grantSchemaPrivileges,
 				pq.QuoteIdentifier(dbName), pq.QuoteIdentifier(rolename),
-				pq.QuoteIdentifier(schema), pq.QuoteIdentifier(rolename),
 				pq.QuoteIdentifier(schema), pq.QuoteIdentifier(rolename),
 				pq.QuoteIdentifier(schema), pq.QuoteIdentifier(rolename),
 				pq.QuoteIdentifier(schema), pq.QuoteIdentifier(rolename),
@@ -594,10 +586,6 @@ func (pc *client) CreateReadOnlyRole(dbName, rolename, schema string) (bool, err
 			-- Grant USAGE on all sequences
 			GRANT USAGE ON ALL SEQUENCES IN SCHEMA %s TO %s;
 			ALTER DEFAULT PRIVILEGES IN SCHEMA %s GRANT USAGE ON SEQUENCES TO %s;
-		
-			-- Grant EXECUTE on all functions
-			GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA %s TO %s;
-			ALTER DEFAULT PRIVILEGES IN SCHEMA %s GRANT EXECUTE ON FUNCTIONS TO %s;
 		`
 		db, err := pc.getDB(dbName)
 		if err != nil {
@@ -609,8 +597,6 @@ func (pc *client) CreateReadOnlyRole(dbName, rolename, schema string) (bool, err
 		_, err = db.Exec(
 			fmt.Sprintf(grantSchemaPrivileges,
 				pq.QuoteIdentifier(dbName), pq.QuoteIdentifier(rolename),
-				pq.QuoteIdentifier(schema), pq.QuoteIdentifier(rolename),
-				pq.QuoteIdentifier(schema), pq.QuoteIdentifier(rolename),
 				pq.QuoteIdentifier(schema), pq.QuoteIdentifier(rolename),
 				pq.QuoteIdentifier(schema), pq.QuoteIdentifier(rolename),
 				pq.QuoteIdentifier(schema), pq.QuoteIdentifier(rolename),


### PR DESCRIPTION
This is to fix the missing CREATE permission on the public schema on GCP databases;

```
identity-api=> SELECT has_schema_privilege('identity-api', 'public', 'CREATE');
 has_schema_privilege
----------------------
 f
(1 row)

identity-api=> SELECT has_schema_privilege('identity-api_a', 'public', 'CREATE');
 has_schema_privilege
----------------------
 f
(1 row)

identity-api=> SELECT has_schema_privilege('identity-api_b', 'public', 'CREATE');
 has_schema_privilege
----------------------
 f
(1 row)
```