### PR TITLE
PTEUDO-2426:relation pg_stat_statements does not exist at character 668

### DIFF
--- a/pkg/databaseclaim/databaseclaim.go
+++ b/pkg/databaseclaim/databaseclaim.go
@@ -480,6 +480,7 @@ func (r *DatabaseClaimReconciler) reconcileUseExistingDB(ctx context.Context, re
 		logr.Error(err, "unable to update users, user credentials not persisted to status object")
 		return err
 	}
+
 	if err = r.statusManager.UpdateStatus(ctx, dbClaim); err != nil {
 		return err
 	}
@@ -491,6 +492,13 @@ func (r *DatabaseClaimReconciler) reconcileUseExistingDB(ctx context.Context, re
 			return err
 		}
 		logr.V(1).Info("password reset, created secret", "secret", dbClaim.Spec.SecretName)
+	}
+	logr.V(1).Info("creating default extensions", "database", dbClaim.Spec.DatabaseName)
+	err = dbClient.CreateDefaultExtensions(dbName)
+	if err != nil {
+		msg := fmt.Sprintf("error creating default extensions for %s", dbName)
+		logr.Error(err, msg)
+		return err
 	}
 	err = dbClient.ManageSystemFunctions(dbName, basefun.GetSystemFunctions(r.Config.Viper))
 	if err != nil {
@@ -587,6 +595,7 @@ func (r *DatabaseClaimReconciler) reconcileNewDB(ctx context.Context, reqInfo *r
 	r.statusManager.UpdateClusterStatus(&dbClaim.Status.NewDB, &reqInfo.HostParams)
 
 	// Updates the database name
+	logr.V(1).Info("creating database and extensions", "database", dbClaim.Spec.DatabaseName)
 	if err := r.createDatabaseAndExtensions(ctx, reqInfo, dbClient, &dbClaim.Status.NewDB, operationalMode); err != nil {
 		logr.Error(err, "unable to create database and extensions")
 		return r.statusManager.SetError(ctx, dbClaim, err)
@@ -1241,7 +1250,8 @@ func (r *DatabaseClaimReconciler) manageUserAndExtensions(ctx context.Context, r
 		}
 	}
 
-	if statusNewDB.UserUpdatedAt == nil || time.Since(statusActiveDB.UserUpdatedAt.Time) >= rotationTime {
+	if statusNewDB.UserUpdatedAt == nil ||
+		(statusActiveDB != nil && statusActiveDB.UserUpdatedAt != nil && time.Since(statusActiveDB.UserUpdatedAt.Time) >= rotationTime) {
 		logger.V(1).Info("rotating_user_password",
 			"currentUser", currentUser,
 			"dbu", dbu,

--- a/pkg/dbclient/client.go
+++ b/pkg/dbclient/client.go
@@ -25,7 +25,7 @@ const (
 
 var defaultExtensions = []string{"citext", "uuid-ossp",
 	"pgcrypto", "hstore", "pg_stat_statements",
-	"plpgsql", "hll"}
+	"plpgsql"}
 
 var specialExtensionsMap = map[string]func(*client, string, string) error{
 	"pg_partman": (*client).CreatePgPartmanExtension,
@@ -224,13 +224,6 @@ func (pc *client) CreateDefaultExtensions(dbName string) error {
 	pc.log.Info("connected to " + dbName)
 	defer db.Close()
 	for _, s := range getDefaulExtensions() {
-		ok, err := pc.CheckExtension(s)
-		if err != nil {
-			return fmt.Errorf("psql_extension_query %s: %w", s, err)
-		}
-		if !ok {
-			continue
-		}
 
 		if _, err = db.Exec(fmt.Sprintf("CREATE EXTENSION IF NOT EXISTS %s", pq.QuoteIdentifier(s))); err != nil {
 			return fmt.Errorf("could not create extension %s: %s", s, err)


### PR DESCRIPTION
Included Fixes:

Today we don't install the default extensions(Not sure if it's intentional or a bug, even though CreateDefaultExtensions method is called while reconciling new db the code actually bypass the installation part --> Fixed

In case of reconciling existing db  the method is not called itself. --> Fixed default extensions to be installed as part of existing db reconciliation. 